### PR TITLE
fix: Remove debug 'Show icon' menu entry

### DIFF
--- a/Reconnect/Views/MainMenu.swift
+++ b/Reconnect/Views/MainMenu.swift
@@ -53,13 +53,6 @@ struct MainMenu: View {
         }
         Divider()
         CheckForUpdatesView(updater: applicationModel.updaterController.updater)
-
-        Divider()
-
-        Button("Show icon") {
-            NSApp.setActivationPolicy(.regular)
-        }
-
         Divider()
         Button("Quit") {
             applicationModel.quit()


### PR DESCRIPTION
I forgot to take this out when working on making the dock icon appear dynamically.