### PR TITLE
fix: Minimize connection restarts

### DIFF
--- a/Reconnect/PLP/Server.swift
+++ b/Reconnect/PLP/Server.swift
@@ -101,15 +101,23 @@ class Server {
             return
         }
 
-        print("Setting devices \(devices)")
+        print("Updating serial devices \(devices)")
 
-        lock.withLock {
+        let needsRestart = lock.withLock {
+            guard self.devices != devices else {
+                return false
+            }
             self.devices = devices
+            return true
         }
 
-        print("Signalling thread...")
+        guard needsRestart else {
+            print("Serial devices haven't changed; ignoring.")
+            return
+        }
+
+        print("Restarting ncpd...")
         pthread_kill(threadID, SIGINT)
-        print("DONE?")
     }
 
 }


### PR DESCRIPTION
This change ensure the ncpd connection is only ever restarted if the list of serial devices changes. Depending on the underlying macOS implementation, it's possible over notification about device changes might have caused unnecessary restarts as we weren't ignoring redundant sets.