### PR TITLE
fix: Single window app model

### DIFF
--- a/Reconnect/ReconnectApp.swift
+++ b/Reconnect/ReconnectApp.swift
@@ -47,7 +47,7 @@ struct ReconnectApp: App {
             }
         }
 
-        WindowGroup("My Psion") {
+        Window("browser", id: "My Psion") {
             ContentView(applicationModel: applicationModel)
         }
         .environment(applicationModel)


### PR DESCRIPTION
This change switches from a window group for the browser window to a single window app. This simplifies the application lifecycle during development and better matches my own personal expectations. We can switch back to a window group if there's demand.