### PR TITLE
fix: Revert single window app model

### DIFF
--- a/Reconnect/ReconnectApp.swift
+++ b/Reconnect/ReconnectApp.swift
@@ -47,7 +47,7 @@ struct ReconnectApp: App {
             }
         }
 
-        Window("browser", id: "My Psion") {
+        WindowGroup("My Psion") {
             ContentView(applicationModel: applicationModel)
         }
         .environment(applicationModel)


### PR DESCRIPTION
This reverts commit a9f5db7759ced936f8d2f752ff28dd041fbc593f.

Unfortunately switching to a single window model means window instance persists across window closes and opens meaning it was no longer possible to close and re-open the window to recover from connection issues. This can be changed back when the connection lifecycle is more reliable.