### PR TITLE
feat: ⬇️ Download toolbar button

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -21,8 +21,8 @@ import SwiftUI
 @MainActor @Observable
 class BrowserModel {
 
-    var canDelete: Bool {
-        return !fileSelection.isEmpty
+    var isSelectionEmpty: Bool {
+        return fileSelection.isEmpty
     }
 
     var navigationTitle: String? {

--- a/Reconnect/Views/BrowserView.swift
+++ b/Reconnect/Views/BrowserView.swift
@@ -87,13 +87,22 @@ struct BrowserView: View {
                 }
             }
 
+            ToolbarItem(id: "download") {
+                Button {
+                    browserModel.download()
+                } label: {
+                    Label("New Folder", systemImage: "square.and.arrow.down")
+                }
+                .disabled(browserModel.isSelectionEmpty)
+            }
+
             ToolbarItem(id: "delete") {
                 Button {
                     browserModel.delete()
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
-                .disabled(!browserModel.canDelete)
+                .disabled(browserModel.isSelectionEmpty)
             }
 
             ToolbarItem(id: "action") {
@@ -108,12 +117,14 @@ struct BrowserView: View {
                     Button("Download") {
                         browserModel.download()
                     }
+                    .disabled(browserModel.isSelectionEmpty)
 
                     Divider()
 
                     Button("Delete") {
                         browserModel.delete()
                     }
+                    .disabled(browserModel.isSelectionEmpty)
 
                 } label: {
                     Label("Action", systemImage: "ellipsis.circle")


### PR DESCRIPTION
This change includes a drive-by fix to ensure the action menu 'Download' and 'Delete' items are correctly disabled when there are no items selected.