### PR TITLE
fix: Converting multi-image bitmaps fails

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -234,8 +234,8 @@ class BrowserModel {
                                 .appendingPathExtension("png")
                             let image = CGImage.from(bitmap: bitmap)
                             try CGImageWritePNG(image, to: conversionURL)
-                            try fileManager.removeItem(at: downloadURL)
                         }
+                        try fileManager.removeItem(at: downloadURL)
                     }
                 }
 


### PR DESCRIPTION
I was performing the cleanup of the original downloaded bitmap file in the loop leading to attempts to delete a non-existent file.