### PR TITLE
fix: 🐇 Support concurrent file browsing and transfers

### DIFF
--- a/Reconnect/PLP/FileServer.swift
+++ b/Reconnect/PLP/FileServer.swift
@@ -144,7 +144,7 @@ class FileServer {
 
     var client = RFSVClient()
 
-    init(host: String, port: Int32) {
+    init(host: String = "127.0.0.1", port: Int32 = 7501) {
         self.host = host
         self.port = port
     }

--- a/Reconnect/Views/BrowserView.swift
+++ b/Reconnect/Views/BrowserView.swift
@@ -22,11 +22,10 @@ import SwiftUI
 struct BrowserView: View {
 
     @Environment(ApplicationModel.self) var applicationModel
-    
-    @State private var browserModel: BrowserModel
 
-    init(fileServer: FileServer) {
-        _browserModel = State(initialValue: BrowserModel(fileServer: fileServer))
+    @State private var browserModel = BrowserModel()
+
+    init() {
     }
 
     var body: some View {

--- a/Reconnect/Views/ContentView.swift
+++ b/Reconnect/Views/ContentView.swift
@@ -21,11 +21,10 @@ import SwiftUI
 struct ContentView: View {
 
     var applicationModel: ApplicationModel
-    let fileServer = FileServer(host: "127.0.0.1", port: 7501)
 
     var body: some View {
         VStack {
-            BrowserView(fileServer: fileServer)
+            BrowserView()
         }
         .showsDockIcon()
     }


### PR DESCRIPTION
The PLP (and plptools) architecture allows for multiple parallel file operaitons. This change takes advantage of that back backing each window with a separate `FileServer` instance and creating an additional instance for long-running file transfers.