### PR TITLE
feat: URL handler to allow one-click copy-to-device / install

### DIFF
--- a/Reconnect/Extensions/URL.swift
+++ b/Reconnect/Extensions/URL.swift
@@ -22,6 +22,7 @@ extension URL {
 
     static let about = URL(string: "x-reconnect://about")!
     static let browser = URL(string: "x-reconnect://browser")!
+    static let install = URL(string: "x-reconnect://install/")!
 
     func appendingPathComponents(_ pathComponents: [String]) -> URL {
         return pathComponents.reduce(self) { url, pathComponent in

--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -46,9 +46,9 @@ class BrowserModel {
         return navigationStack.previousItems.reversed()
     }
 
-    var transfersModel = TransfersModel()
-
     let fileServer = FileServer()
+
+    let transfersModel: TransfersModel
 
     var drives: [FileServer.DriveInfo] = []
     var files: [FileServer.DirectoryEntry] = []
@@ -68,7 +68,8 @@ class BrowserModel {
 
     private var navigationStack = NavigationStack()
 
-    init() {
+    init(transfersModel: TransfersModel) {
+        self.transfersModel = transfersModel
     }
 
     func start() async {

--- a/Reconnect/ReconnectApp.swift
+++ b/Reconnect/ReconnectApp.swift
@@ -22,12 +22,13 @@ import Diligence
 import Interact
 import Sparkle
 
-@main
+@main @MainActor
 struct ReconnectApp: App {
 
     static let title = "Reconnect Support (\(Bundle.main.extendedVersion ?? "Unknown Version"))"
 
     @State var server = Server()
+    @State var transfersModel = TransfersModel()
     @State var applicationModel: ApplicationModel
 
     init() {
@@ -48,10 +49,23 @@ struct ReconnectApp: App {
         }
 
         WindowGroup("My Psion") {
-            ContentView(applicationModel: applicationModel)
+            ContentView(applicationModel: applicationModel, transfersModel: transfersModel)
+                .onOpenURL { url in
+                    print(url)
+                    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                          let path = components.queryItems?.first(where: { $0.name == "path" })?.value,
+                          let installerURL = URL(string: path),
+                          installerURL.scheme == "file"
+                    else {
+                        return
+                    }
+                    let filename = installerURL.lastPathComponent
+                    transfersModel.upload(from: installerURL, to: "C:".appendingWindowsPathComponent(filename))
+                }
+                .handlesExternalEvents(preferring: [.install, .browser], allowing: [])
         }
         .environment(applicationModel)
-        .handlesExternalEvents(matching: [.browser])
+        .handlesExternalEvents(matching: [.browser, .install])
 
         About(repository: "inseven/reconnect", copyright: "Copyright © 2024 Jason Morley") {
             Action("GitHub", url: URL(string: "https://github.com/inseven/reconnect")!)

--- a/Reconnect/Views/BrowserView.swift
+++ b/Reconnect/Views/BrowserView.swift
@@ -23,9 +23,10 @@ struct BrowserView: View {
 
     @Environment(ApplicationModel.self) var applicationModel
 
-    @State private var browserModel = BrowserModel()
+    @State private var browserModel: BrowserModel
 
-    init() {
+    init(transfersModel: TransfersModel) {
+        _browserModel = State(initialValue: BrowserModel(transfersModel: transfersModel))
     }
 
     var body: some View {

--- a/Reconnect/Views/ContentView.swift
+++ b/Reconnect/Views/ContentView.swift
@@ -21,10 +21,16 @@ import SwiftUI
 struct ContentView: View {
 
     var applicationModel: ApplicationModel
+    var transfersModel: TransfersModel
+
+    init(applicationModel: ApplicationModel, transfersModel: TransfersModel) {
+        self.applicationModel = applicationModel
+        self.transfersModel = transfersModel
+    }
 
     var body: some View {
         VStack {
-            BrowserView()
+            BrowserView(transfersModel: transfersModel)
         }
         .showsDockIcon()
     }


### PR DESCRIPTION
This change adds a handler for `x-reconnect://install/` URLs. They accept a `path` parameter of a file URL (e.g., `file:///Users/jbmorley/installer.sis`) and will copy the specified file to the connected Psion. Longer-term this should kick-off a managed install in Reconnect. Nearer-term, it could perhaps launch the Installer on the Psion on transfer completion.