### PR TITLE
refactor: Create ReconnectCore package for sharing code between multiple targets

### DIFF
--- a/Reconnect.xcodeproj/project.pbxproj
+++ b/Reconnect.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		D8AD8B522C2378780063A613 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AD8B512C2378780063A613 /* Server.swift */; };
 		D8C0807A2C1D7D8D003128AB /* ReconnectError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C080792C1D7D8D003128AB /* ReconnectError.swift */; };
 		D8C409CA2C3D0B7600C9E857 /* Graphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C409C92C3D0B7600C9E857 /* Graphics.swift */; };
+		D8CBAC652C4A02580035FC3D /* ReconnectCore in Frameworks */ = {isa = PBXBuildFile; productRef = D8CBAC642C4A02580035FC3D /* ReconnectCore */; };
 		D8D3E79D2C25407E003E696D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3E79C2C25407E003E696D /* URL.swift */; };
 		D8D3E79F2C2540D9003E696D /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8D3E79E2C2540D9003E696D /* Interact */; };
 		D8D3E7A12C25410E003E696D /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3E7A02C25410E003E696D /* MainMenu.swift */; };
@@ -118,6 +119,7 @@
 		D8AD8B532C2379A10063A613 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8C080792C1D7D8D003128AB /* ReconnectError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectError.swift; sourceTree = "<group>"; };
 		D8C409C92C3D0B7600C9E857 /* Graphics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Graphics.swift; sourceTree = "<group>"; };
+		D8CBAC632C4A022C0035FC3D /* ReconnectCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ReconnectCore; sourceTree = "<group>"; };
 		D8D3E79C2C25407E003E696D /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		D8D3E7A02C25410E003E696D /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
 		D8E31EB42C26E10900350082 /* Licensable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licensable.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8DF2C112C3CE8AC006E56BA /* OpoLua in Frameworks */,
+				D8CBAC652C4A02580035FC3D /* ReconnectCore in Frameworks */,
 				D806342B2C27F87100DEA6DA /* plpftp in Frameworks */,
 				D81A0C162C27A90000EC2929 /* ncp in Frameworks */,
 				D8E31EB32C26E09500350082 /* Diligence in Frameworks */,
@@ -205,6 +208,7 @@
 		D84964CD2C1BFCB600405656 = {
 			isa = PBXGroup;
 			children = (
+				D8CBAC632C4A022C0035FC3D /* ReconnectCore */,
 				D84964D82C1BFCB600405656 /* Reconnect */,
 				D84964EA2C1BFCB700405656 /* ReconnectTests */,
 				D84964F42C1BFCB700405656 /* ReconnectUITests */,
@@ -334,6 +338,7 @@
 				D806342A2C27F87100DEA6DA /* plpftp */,
 				D88FA14D2C2CE0FA00805DBD /* Sparkle */,
 				D8DF2C102C3CE8AC006E56BA /* OpoLua */,
+				D8CBAC642C4A02580035FC3D /* ReconnectCore */,
 			);
 			productName = PsiMac;
 			productReference = D84964D62C1BFCB600405656 /* Reconnect.app */;
@@ -878,6 +883,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D88FA14C2C2CE0FA00805DBD /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		D8CBAC642C4A02580035FC3D /* ReconnectCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ReconnectCore;
 		};
 		D8D3E79E2C2540D9003E696D /* Interact */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ReconnectCore/.gitignore
+++ b/ReconnectCore/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ReconnectCore/Package.swift
+++ b/ReconnectCore/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ReconnectCore",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "ReconnectCore",
+            targets: ["ReconnectCore"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "ReconnectCore"),
+        .testTarget(
+            name: "ReconnectCoreTests",
+            dependencies: ["ReconnectCore"]),
+    ]
+)

--- a/ReconnectCore/Sources/ReconnectCore/ReconnectCore.swift
+++ b/ReconnectCore/Sources/ReconnectCore/ReconnectCore.swift
@@ -1,0 +1,17 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.

--- a/ReconnectCore/Tests/ReconnectCoreTests/ReconnectCoreTests.swift
+++ b/ReconnectCore/Tests/ReconnectCoreTests/ReconnectCoreTests.swift
@@ -1,0 +1,24 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import XCTest
+@testable import ReconnectCore
+
+final class ReconnectCoreTests: XCTestCase {
+
+}


### PR DESCRIPTION
This is preparatory work for separating Reconnect out into two separate apps: a transient GUI app, and a resident Menu Bar app. The architecture of plptools makes this kind of separation fairly easy, but we still need to share some code between the apps in the form of this new core package.

The user-facing goal of this separation is to address the issue of multitasking focus in macOS when dynamically hiding and showing the Dock icon.