### PR TITLE
fix: Support creating more than one new 'untitled folder'

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -169,8 +169,8 @@ class BrowserModel {
             var name = "untitled folder"
             var folderNumber = 1
             while names.contains(name) {
-                name = "untitled folder \(folderNumber)"
                 folderNumber += 1
+                name = "untitled folder \(folderNumber)"
             }
 
             // Create the folder.


### PR DESCRIPTION
This change follows the macOS pattern of appending a count to the 'untitled folder' name if one already exists in the current directory.