### PR TITLE
fix: Close the transfers window if clearing it removes all items

### DIFF
--- a/Reconnect/Views/TransfersView.swift
+++ b/Reconnect/Views/TransfersView.swift
@@ -61,7 +61,11 @@ struct TransfersView: View {
 
                     Button("Clear") {
                         transfersModel.clear()
+                        if transfersModel.transfers.isEmpty {
+                            dismiss()
+                        }
                     }
+                    .disabled(transfersModel.transfers.isEmpty)
                 }
                 .padding(LayoutMetrics.footerPadding)
             }


### PR DESCRIPTION
This change also disables the clear button if there are no items.