### PR TITLE
fix: Refresh the browser when uploads complete

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -220,7 +220,9 @@ class BrowserModel {
             if file.path.isWindowsDirectory {
                 downloadDirectory(path: file.path, convertFiles: convertFiles)
             } else {
-                transfersModel.download(from: file, convertFiles: convertFiles)
+                Task {
+                    try? await transfersModel.download(from: file, convertFiles: convertFiles)
+                }
             }
         }
     }
@@ -243,7 +245,11 @@ class BrowserModel {
                 if file.isDirectory {
                     try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
                 } else {
-                    self.transfersModel.download(from: file, to: destinationURL, convertFiles: convertFiles)
+                    Task {
+                        try? await self.transfersModel.download(from: file,
+                                                                to: destinationURL,
+                                                                convertFiles: convertFiles)
+                    }
                 }
             }
         }
@@ -255,7 +261,8 @@ class BrowserModel {
             guard let path = self.path else {
                 throw ReconnectError.invalidFilePath
             }
-            self.transfersModel.upload(from: url, to: path + url.lastPathComponent)
+            try? await self.transfersModel.upload(from: url, to: path + url.lastPathComponent)
+            self.refresh()
         }
     }
 

--- a/Reconnect/Windows/TransfersWindow.swift
+++ b/Reconnect/Windows/TransfersWindow.swift
@@ -38,7 +38,9 @@ struct TransfersWindow: Scene {
                         return
                     }
                     let filename = installerURL.lastPathComponent
-                    transfersModel.upload(from: installerURL, to: "C:".appendingWindowsPathComponent(filename))
+                    Task {
+                        try? await transfersModel.upload(from: installerURL, to: "C:".appendingWindowsPathComponent(filename))
+                    }
                 }
                 .handlesExternalEvents(preferring: [.install], allowing: [])
         }


### PR DESCRIPTION
This changes makes `TransfersModel.upload` and `TransfersModel.download` async to allow callers to await upload and download operations.