### PR TITLE
fix: Convert MBMs to TIFF files

### DIFF
--- a/Reconnect/Model/FileReference.swift
+++ b/Reconnect/Model/FileReference.swift
@@ -20,7 +20,7 @@ import Foundation
 
 import ReconnectCore
 
-enum FileReference {
+enum FileReference: Equatable {
 
     case local(URL)
     case remote(FileServer.DirectoryEntry)

--- a/Reconnect/Model/TransfersModel.swift
+++ b/Reconnect/Model/TransfersModel.swift
@@ -66,21 +66,19 @@ class TransfersModel {
             // Convert known types.
             // N.B. This would be better implemented as a user-configurable and extensible pipeline, but this is a
             // reasonable point to hook an initial implementation.
-            var urls: [URL] = [destinationURL]
+            var url: URL = destinationURL
             if convertFiles {
                 if directoryEntry.fileType == .mbm || directoryEntry.pathExtension.lowercased() == "mbm" {
-                    urls = try PsiLuaEnv().convertMultiBitmap(at: destinationURL, removeSource: true)
+                    url = try PsiLuaEnv().convertMultiBitmap(at: destinationURL, removeSource: true)
                 }
             }
 
             // Get the file details.
-            let details = try urls.map { url in
-                let size = try FileManager.default.attributesOfItem(atPath: url.path)[.size] as! UInt64
-                return Transfer.FileDetails(url: url, size: size)
-            }
+            let size = try FileManager.default.attributesOfItem(atPath: url.path)[.size] as! UInt64
+            let details = Transfer.FileDetails(url: url, size: size)
 
             // Mark the transfer as complete.
-            transfer.setStatus(.complete(details.first))
+            transfer.setStatus(.complete(details))
         }
         transfers.append(download)
         try await download.run()

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/PsiLuaEnv.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/PsiLuaEnv.swift
@@ -23,27 +23,21 @@ import OpoLua
 
 extension PsiLuaEnv {
 
-    public func convertMultiBitmap(at url: URL, removeSource: Bool = false) throws -> [URL] {
+    public func convertMultiBitmap(at url: URL, removeSource: Bool = false) throws -> URL {
         let directoryURL = (url as NSURL).deletingLastPathComponent!
         let basename = (url.lastPathComponent as NSString).deletingPathExtension
         let bitmaps = PsiLuaEnv().getMbmBitmaps(path: url.path) ?? []
-        let urls = try bitmaps.enumerated().map { index, bitmap in
-            let identifier = if index < 1 {
-                basename
-            } else {
-                "\(basename) \(index)"
-            }
-            let conversionURL = directoryURL
-                .appendingPathComponent(identifier)
-                .appendingPathExtension("png")
-            let image = CGImage.from(bitmap: bitmap)
-            try CGImageWritePNG(image, to: conversionURL)
-            return conversionURL
+        let images = bitmaps.map { bitmap in
+            return CGImage.from(bitmap: bitmap)
         }
+        let conversionURL = directoryURL
+            .appendingPathComponent(basename)
+            .appendingPathExtension("tiff")
+        try CGImageWriteTIFF(destinationURL: conversionURL, images: images)
         if removeSource {
             try FileManager.default.removeItem(at: url)
         }
-        return urls
+        return conversionURL
     }
 
 }

--- a/ReconnectCore/Sources/ReconnectCore/Utilities/Graphics.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Utilities/Graphics.swift
@@ -20,14 +20,16 @@ import Foundation
 import ImageIO
 import UniformTypeIdentifiers
 
-public func CGImageWritePNG(_ image: CGImage, to destinationURL: URL) throws  {
+public func CGImageWriteTIFF(destinationURL: URL, images: [CGImage]) throws  {
     guard let destination = CGImageDestinationCreateWithURL(destinationURL as CFURL,
-                                                            UTType.png.identifier as CFString,
-                                                            1,
+                                                            UTType.tiff.identifier as CFString,
+                                                            images.count,
                                                             nil) else {
         throw ReconnectError.imageSaveError
     }
-    CGImageDestinationAddImage(destination, image, nil)
+    for image in images {
+        CGImageDestinationAddImage(destination, image, nil)
+    }
     guard CGImageDestinationFinalize(destination) else {
         throw ReconnectError.imageSaveError
     }


### PR DESCRIPTION
TIFFs support multiple-images which makes them a simpler conversion target.