### PR TITLE
docs: Ensure the download button works correclty

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
     <div class="appname">Reconnect</div>
     <div class="tagline">{{ site.description }}</div>
     <div class="actions">
-        <a class="button" href="{{ site.env.DOWNLOAD_URL }}">Download</a>
+        <a class="button no-rewrite" href="{{ site.env.DOWNLOAD_URL }}">Download</a>
     </div>
 </p>
 

--- a/docs/js/rewrite-external-links.js
+++ b/docs/js/rewrite-external-links.js
@@ -20,6 +20,7 @@ observe((root) => {
         var element = elements.snapshotItem(i);
         if (element.hasAttribute("href") &&
             element.getAttribute("href").startsWith("http") &&
+            !element.classList.contains("no-rewrite") &&
             element.target != "_blank") {
             element.target="_blank";
         }


### PR DESCRIPTION
In Safari (and perhaps other browsers), having `target=“_blank”` on download links seems to interact poorly with the download permissions dialog. This adds a mechanism to opt-out of external link rewriting and applies this to the download button.