### PR TITLE
refactor: Make `FileServer.rmdir` and `FileServer.remove` synchronous

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -211,14 +211,14 @@ class BrowserModel {
     func delete(_ selection: Set<FileServer.DirectoryEntry.ID>? = nil) {
         dispatchPrecondition(condition: .onQueue(.main))
         let selection = selection ?? fileSelection
-        runAsync {
+        run {
             for path in selection {
                 if path.isWindowsDirectory {
-                    try await self.fileServer.rmdir(path: path)
+                    try self.fileServer.rmdir(path: path)
                 } else {
-                    try await self.fileServer.remove(path: path)
+                    try self.fileServer.remove(path: path)
                 }
-                await MainActor.run {
+                DispatchQueue.main.sync {
                     self.files.removeAll { $0.path == path }
                     self.fileSelection.remove(path)
                 }

--- a/Reconnect/Model/InstallerModel.swift
+++ b/Reconnect/Model/InstallerModel.swift
@@ -365,7 +365,7 @@ extension InstallerModel: SisInstallIoHandler {
                 DispatchQueue.main.sync {
                     self.page = .delete(operation.path)
                 }
-                try fileServer.removeSync(path: operation.path)
+                try fileServer.remove(path: operation.path)
                 return .success
             case .mkdir:
                 try fileServer.mkdir(path: operation.path)

--- a/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
+++ b/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
@@ -234,9 +234,9 @@ public class FileServer: @unchecked Sendable {
         return DirectoryEntry(directoryPath: path.deletingLastWindowsPathComponent, entry: entry)
     }
 
-    func workQueue_copyFile(fromRemotePath remoteSourcePath: String,
-                            toLocalPath localDestinationPath: String,
-                            callback: @escaping (UInt32, UInt32) -> ProgressResponse) throws(PLPToolsError) {
+    private func workQueue_copyFile(fromRemotePath remoteSourcePath: String,
+                                    toLocalPath localDestinationPath: String,
+                                    callback: @escaping (UInt32, UInt32) -> ProgressResponse) throws(PLPToolsError) {
         dispatchPrecondition(condition: .onQueue(workQueue))
         try workQueue_connect()
 
@@ -253,9 +253,9 @@ public class FileServer: @unchecked Sendable {
         try result.check()
     }
 
-    func workQueue_copyFile(fromLocalPath localSourcePath: String,
-                            toRemotePath remoteDestinationPath: String,
-                            callback: @escaping (UInt32, UInt32) -> ProgressResponse) throws {
+    private func workQueue_copyFile(fromLocalPath localSourcePath: String,
+                                    toRemotePath remoteDestinationPath: String,
+                                    callback: @escaping (UInt32, UInt32) -> ProgressResponse) throws {
         dispatchPrecondition(condition: .onQueue(workQueue))
         try workQueue_connect()
         let attributes = try FileManager.default.attributesOfItem(atPath: localSourcePath)
@@ -425,19 +425,13 @@ public class FileServer: @unchecked Sendable {
         }
     }
 
-    public func rmdir(path: String) async throws {
-        try await perform {
+    public func rmdir(path: String) throws {
+        try performSync {
             try self.workQueue_rmdir(path: path)
         }
     }
 
-    public func remove(path: String) async throws {
-        try await perform {
-            try self.workQueue_remove(path: path)
-        }
-    }
-
-    public func removeSync(path: String) throws(PLPToolsError) {
+    public func remove(path: String) throws(PLPToolsError) {
         try performSync { () throws(PLPToolsError) in
             try self.workQueue_remove(path: path)
         }


### PR DESCRIPTION
This change includes a drive-by fix to make the `workQueue_copyFile` functions private.