### PR TITLE
fix: 📁 Support installing files to the root of drives

### DIFF
--- a/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
+++ b/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
@@ -236,14 +236,14 @@ public class FileServer: @unchecked Sendable {
                 return true
             } catch {
                 // Drive not ready indicates the drive doesn't exist instead of a hard failure.
-                guard error.errorCode == .driveNotReady else {
+                guard error == .driveNotReady else {
                     throw error
                 }
                 return false
             }
         } else {
             var exists: Bool = false
-            try client.pathtest(path, &exists).check(context: "Path test '\(path)'")
+            try client.pathtest(path, &exists).check()
             return exists
         }
     }
@@ -252,7 +252,7 @@ public class FileServer: @unchecked Sendable {
         dispatchPrecondition(condition: .onQueue(workQueue))
         try workQueue_connect()
         var entry = PlpDirent()
-        try client.fgeteattr(path, &entry).check(context: "Get extended attributes '\(path)'")
+        try client.fgeteattr(path, &entry).check()
         return DirectoryEntry(directoryPath: path.deletingLastWindowsPathComponent, entry: entry)
     }
 


### PR DESCRIPTION
Psions treat existance checks for drive roots differently to regular files and directoires meaning we were incorrectly reporting `C:\` as not found, resulting in an attempt to create the path, and subsequent failure as it already existed 🤦🏻‍♂️.

This change catches up to an updated version of plptools which includes a new exists check. We adopt this to avoid having to get extended attributes as a proxy for the exists check, and also explicitly query drive info for drive-root paths to check they exist.