### PR TITLE
fix: ⚙️ Speed up checking for existing files during install

### DIFF
--- a/Reconnect/Model/InstallerModel.swift
+++ b/Reconnect/Model/InstallerModel.swift
@@ -393,12 +393,12 @@ extension InstallerModel: SisInstallIoHandler {
                 }
                 return .success
             case .stat:
-                // We know the installer doesn't care about anything other than knowing the file exists so we simply
-                // check to see that it exists and fake the other values to avoid doing unnecessary work.
-                guard try fileServer.exists(path: operation.path) else {
-                    return .err(.notFound)
-                }
-                return .stat(Fs.Stat(size: 0, lastModified: .now, isDirectory: operation.path.isWindowsDirectory))
+                let attributes = try fileServer.getExtendedAttributesSync(path: operation.path)
+                return .stat(Fs.Stat(size: UInt64(attributes.size),
+                                     lastModified: attributes.modificationDate,
+                                     isDirectory: attributes.isDirectory))
+            case .exists:
+                return try fileServer.exists(path: operation.path) ? .success : .err(.notFound)
             default:
                 print("Unsupported operation '\(operation.type)' '\(operation.path)'")
                 return .err(.notReady)


### PR DESCRIPTION
This change catches up to the latest OpoLua update which allows us to take advantage of the new `exists` check instead of performing a `stat` when checking to see if files and directories need to be created during install.