### PR TITLE
fix: 🔎 Show more details during installation

### DIFF
--- a/Reconnect/Views/Installer/InstallerView.swift
+++ b/Reconnect/Views/Installer/InstallerView.swift
@@ -85,13 +85,22 @@ struct InstallerView: View {
                     Button("Cancel", role: .destructive) {}
                         .disabled(true)
                 }
-            case .copy(let path, let progress):
+            case .operation(let operation, let progress):
                 InstallerPage {
                     VStack {
-                        Text("Copying '\(path)'...")
+                        switch operation.type {
+                        case .write:
+                            Text("Copying '\(operation.path)'...")
+                        case .delete:
+                            Text("Deleting '\(operation.path)'...")
+                        case .mkdir:
+                            Text("Creating directory '\(operation.path)'...")
+                        default:
+                            Text(operation.path)
+                        }
                         AnimatedImage(named: "install")
                             .frame(width: 240, height: 70)
-                        ProgressView(value: progress)
+                        ProgressView(value: progress.fractionCompleted)
                     }
                     .padding()
                     .frame(maxWidth: LayoutMetrics.maximumContentWidth)
@@ -99,18 +108,6 @@ struct InstallerView: View {
                     Button("Cancel", role: .destructive) {}
                         .disabled(true)
                 }
-            case .delete(let path):
-                InstallerPage {
-                    VStack {
-                        Text("Deleting '\(path)'...")
-                    }
-                    .padding()
-                    .frame(maxWidth: LayoutMetrics.maximumContentWidth)
-                } actions: {
-                    Button("Cancel", role: .destructive) {}
-                        .disabled(true)
-                }
-
             case .complete:
                 InstallerPage {
                     VStack {
@@ -169,7 +166,7 @@ struct InstallerView: View {
             guard let newValue else {
                 return
             }
-            window.title = newValue.localizedDisplayName
+            window.title = newValue.localizedDisplayNameAndVersion
         }
         .runs(installerModel)
     }

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
@@ -20,6 +20,7 @@ import Foundation
 
 public extension String {
 
+    static let installDirectory = "C:\\System\\Install\\"
     static let windowsPathSeparator = "\\"
 
     var deletingLastWindowsPathComponent: String {


### PR DESCRIPTION
This change improves the progress reporting during SIS file installs.

Under the hood, it adds generalized support for performing `Fs.Operation` operations to `FileServer` and adds consistent progress reporting for all operations. The plan is to allow greater reuse across new features.