### PR TITLE
fix: 👌🏻 Use consistent installer name and version formatting

### DIFF
--- a/Reconnect/Views/Installer/ConfigurationQueryInstallerPage.swift
+++ b/Reconnect/Views/Installer/ConfigurationQueryInstallerPage.swift
@@ -37,7 +37,7 @@ struct ConfigurationQueryInstallerPage: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            InstallerPage("Install '\(query.sis.localizedDisplayName)'?") {
+            InstallerPage("Install '\(query.sis.localizedDisplayNameAndVersion)'?") {
                 Form {
                     if languages.count > 1 {
                         LabeledContent("Language") {

--- a/Reconnect/Views/Installer/InstallerView.swift
+++ b/Reconnect/Views/Installer/InstallerView.swift
@@ -166,7 +166,7 @@ struct InstallerView: View {
             guard let newValue else {
                 return
             }
-            window.title = newValue.localizedDisplayName
+            window.title = newValue.localizedDisplayNameAndVersion
         }
         .runs(installerModel)
     }

--- a/Reconnect/Views/Installer/TextQueryInstallerPage.swift
+++ b/Reconnect/Views/Installer/TextQueryInstallerPage.swift
@@ -24,7 +24,7 @@ struct TextQueryInstallerPage: View {
     let query: InstallerModel.TextQuery
 
     var body: some View {
-        InstallerPage(query.sis.localizedDisplayName) {
+        InstallerPage(query.sis.localizedDisplayNameAndVersion) {
             ScrollView {
                 Text(query.text)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/Sis.File.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/Sis.File.swift
@@ -29,7 +29,11 @@ extension Sis.File: @retroactive Identifiable, @retroactive Equatable {
     public var id: String { "\(uid):\(version)" }
 
     public var localizedDisplayName: String {
-        return "\((try? Locale.localize(name).text) ?? "Unknown Installer") - \(version)"
+        return (try? Locale.localize(name).text) ?? "Unknown Installer"
+    }
+
+    public var localizedDisplayNameAndVersion: String {
+        return "\(localizedDisplayName) \(version)"
     }
 
 }

--- a/ReconnectPreviews/InstallerPreviewView.swift
+++ b/ReconnectPreviews/InstallerPreviewView.swift
@@ -27,7 +27,7 @@ struct InstallerPreviewView: View {
 
     var body: some View {
         VStack(alignment: .center) {
-            Text((try? Locale.localize(file.name))?.text ?? "Unknown Name")
+            Text(file.localizedDisplayName)
                 .multilineTextAlignment(.center)
                 .font(.title)
             Text("\(file.version.major).\(file.version.minor)")


### PR DESCRIPTION
This introduces a new `Sis.File.localizedDisplayNameAndVersion` computed property to make it distinct from `localizedDisplayName` which now returns just the SIS file display name. It also updates the formatting of the display name and version to omit the hyphen between the two to better match EPOC32's formatting.