### PR TITLE
refactor: Switch some Xcode project groups to folders

### DIFF
--- a/Reconnect.xcodeproj/project.pbxproj
+++ b/Reconnect.xcodeproj/project.pbxproj
@@ -8,21 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		D8068F6F2C4AFCF4004177F6 /* ReconnectCore in Frameworks */ = {isa = PBXBuildFile; productRef = D8068F6E2C4AFCF4004177F6 /* ReconnectCore */; };
-		D8068F722C4AFF29004177F6 /* BrowserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8068F712C4AFF29004177F6 /* BrowserWindow.swift */; };
 		D809546E2C4AACF100752BBC /* Reconnect Menu.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8F1A59B2C4A4C9B00931C00 /* Reconnect Menu.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D813FF152C26E869009CF0DC /* plptools-license in Resources */ = {isa = PBXBuildFile; fileRef = D813FF142C26E869009CF0DC /* plptools-license */; };
-		D8184C472C253C59008FA79B /* ApplicationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8184C462C253C59008FA79B /* ApplicationModel.swift */; };
 		D820123F2DE1170700854FE9 /* HelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D820123E2DE1170200854FE9 /* HelpCommands.swift */; };
 		D83658B72C29596F00B45693 /* NavigationHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83658B62C29596F00B45693 /* NavigationHistoryTests.swift */; };
 		D83658B92C298C4F00B45693 /* NavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83658B82C298C4F00B45693 /* NavigationHistory.swift */; };
-		D83658BB2C29A09300B45693 /* HistoryItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83658BA2C29A09300B45693 /* HistoryItemView.swift */; };
-		D83A786A2C3C80C9000E8192 /* FileTypePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83A78692C3C80C9000E8192 /* FileTypePopover.swift */; };
-		D83B4DDF2C2F9995003C3DC1 /* CheckForUpdatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B4DDE2C2F9995003C3DC1 /* CheckForUpdatesView.swift */; };
-		D83B4DE12C2F99C3003C3DC1 /* CheckForUpdatesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B4DE02C2F99C3003C3DC1 /* CheckForUpdatesViewModel.swift */; };
 		D83BD9662DE862AB0075902D /* SwiftyGif in Frameworks */ = {isa = PBXBuildFile; productRef = D83BD9652DE862AB0075902D /* SwiftyGif */; };
 		D83BD96E2DE86C100075902D /* SSSwiftUIGIFView in Frameworks */ = {isa = PBXBuildFile; productRef = D83BD96D2DE86C100075902D /* SSSwiftUIGIFView */; };
-		D83BD9752DE8E2390075902D /* AnimagedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83BD9742DE8E2370075902D /* AnimagedImage.swift */; };
-		D83BD9772DE8F4B40075902D /* NSInstallerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83BD9762DE8F4B10075902D /* NSInstallerWindow.swift */; };
 		D83BD9792DE914B40075902D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83BD9782DE914B20075902D /* AppDelegate.swift */; };
 		D84964DA2C1BFCB600405656 /* ReconnectApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84964D92C1BFCB600405656 /* ReconnectApp.swift */; };
 		D84964DE2C1BFCB700405656 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D84964DD2C1BFCB700405656 /* Assets.xcassets */; };
@@ -30,31 +22,17 @@
 		D84964EC2C1BFCB700405656 /* ReconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84964EB2C1BFCB700405656 /* ReconnectTests.swift */; };
 		D84964F62C1BFCB700405656 /* ReconnectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84964F52C1BFCB700405656 /* ReconnectUITests.swift */; };
 		D84964F82C1BFCB700405656 /* ReconnectUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84964F72C1BFCB700405656 /* ReconnectUITestsLaunchTests.swift */; };
-		D8631DAB2C36867400344DC3 /* BrowserDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DAA2C36867300344DC3 /* BrowserDetailView.swift */; };
-		D8631DAF2C373A1600344DC3 /* TransferRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DAE2C373A1600344DC3 /* TransferRow.swift */; };
-		D8631DB12C374B0A00344DC3 /* Transfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DB02C374B0A00344DC3 /* Transfer.swift */; };
-		D8631DB32C374B4400344DC3 /* TransfersModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DB22C374B4400344DC3 /* TransfersModel.swift */; };
-		D8631DB52C374F8700344DC3 /* TransfersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DB42C374F8700344DC3 /* TransfersView.swift */; };
 		D8631DB92C375F2400344DC3 /* WindowsPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8631DB82C375F2400344DC3 /* WindowsPathTests.swift */; };
 		D874B0CC2DEE4EB1008E938D /* SisInstallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D874B0CB2DEE4EAE008E938D /* SisInstallError.swift */; };
-		D886DA742C28CDAD00E84BDA /* BrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D886DA732C28CDAD00E84BDA /* BrowserView.swift */; };
-		D886DA762C29343900E84BDA /* BrowserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D886DA752C29343900E84BDA /* BrowserModel.swift */; };
 		D88FA14E2C2CE0FA00805DBD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D88FA14D2C2CE0FA00805DBD /* Sparkle */; };
 		D890718B2C4B01FC00C11DE8 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = D890718A2C4B01FC00C11DE8 /* Command.swift */; };
 		D89071912C4B025D00C11DE8 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = D89071902C4B025D00C11DE8 /* ArgumentParser */; };
 		D89071932C4B02D900C11DE8 /* ReconnectCore in Frameworks */ = {isa = PBXBuildFile; productRef = D89071922C4B02D900C11DE8 /* ReconnectCore */; };
 		D8981E422DE3B03F003CBCF0 /* FileCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8981E412DE3B03C003CBCF0 /* FileCommands.swift */; };
 		D8981E442DE3B14F003CBCF0 /* SparkleCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8981E432DE3B14D003CBCF0 /* SparkleCommands.swift */; };
-		D89B5E8E2C2AA8680014A5B6 /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89B5E8D2C2AA8680014A5B6 /* Sidebar.swift */; };
 		D8A8A8082DE19312007A657B /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = D8A8A8072DE19312007A657B /* Algorithms */; };
-		D8A8A80A2DE1A095007A657B /* EditableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8A8092DE1A093007A657B /* EditableText.swift */; };
-		D8A8A80C2DE1A0B6007A657B /* EditableTextModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8A80B2DE1A0B4007A657B /* EditableTextModel.swift */; };
 		D8A8A80E2DE1A7A0007A657B /* apache-2.0-license in Resources */ = {isa = PBXBuildFile; fileRef = D8A8A80D2DE1A799007A657B /* apache-2.0-license */; };
-		D8AB7ED32D0AA1140076E19F /* FileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB7ED22D0AA1130076E19F /* FileReference.swift */; };
-		D8AB9C342DEE3A230087F13E /* TextQueryInstallerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB9C332DEE3A1E0087F13E /* TextQueryInstallerPage.swift */; };
 		D8AB9C382DEE3EFE0087F13E /* WindowProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB9C372DEE3EFC0087F13E /* WindowProxy.swift */; };
-		D8AC642C2D0D58970085306B /* ThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AC642B2D0D58910085306B /* ThumbnailView.swift */; };
-		D8AC642E2D0D5B4D0085306B /* PixelImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AC642D2D0D5B4A0085306B /* PixelImage.swift */; };
 		D8AE29A82CA25A9800116439 /* PsionSoftwareIndex in Frameworks */ = {isa = PBXBuildFile; productRef = D8AE29A72CA25A9800116439 /* PsionSoftwareIndex */; };
 		D8B1AC452E0F4C220084BFD5 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8B1AC442E0F4C220084BFD5 /* Quartz.framework */; };
 		D8B1AC532E0F4C220084BFD5 /* ReconnectPreviews.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D8B1AC432E0F4C220084BFD5 /* ReconnectPreviews.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -67,14 +45,8 @@
 		D8B1AC6A2E0F88380084BFD5 /* PreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B1AC612E0F88380084BFD5 /* PreviewViewController.swift */; };
 		D8CBAC652C4A02580035FC3D /* ReconnectCore in Frameworks */ = {isa = PBXBuildFile; productRef = D8CBAC642C4A02580035FC3D /* ReconnectCore */; };
 		D8D362992DE79CB000DDDD19 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D8D362972DE79CB000DDDD19 /* Localizable.strings */; };
-		D8D3629B2DE7A23900DDDD19 /* InstallerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3629A2DE7A23700DDDD19 /* InstallerPage.swift */; };
 		D8D3E79F2C2540D9003E696D /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8D3E79E2C2540D9003E696D /* Interact */; };
-		D8D5E3772DEB858500FEFBE1 /* ConfigurationQueryInstallerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D5E3762DEB858100FEFBE1 /* ConfigurationQueryInstallerPage.swift */; };
 		D8DC357F2E0F37C700471D7D /* NavigationCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DC357E2E0F37C100471D7D /* NavigationCommands.swift */; };
-		D8DE6DF92DF0DACF00E39CE2 /* ReplaceQueryInstallerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DE6DF82DF0DACE00E39CE2 /* ReplaceQueryInstallerPage.swift */; };
-		D8DECF462DE62876004DE55C /* InstallerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DECF452DE62874004DE55C /* InstallerView.swift */; };
-		D8DECF482DE62890004DE55C /* InstallerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DECF472DE6288C004DE55C /* InstallerModel.swift */; };
-		D8E2325C2DE1117800879866 /* FileConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E2325B2DE1117400879866 /* FileConverter.swift */; };
 		D8E31EB32C26E09500350082 /* Diligence in Frameworks */ = {isa = PBXBuildFile; productRef = D8E31EB22C26E09500350082 /* Diligence */; };
 		D8E31EB52C26E10900350082 /* Licensable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E31EB42C26E10900350082 /* Licensable.swift */; };
 		D8E31EBA2C26E1E400350082 /* reconnect-license in Resources */ = {isa = PBXBuildFile; fileRef = D8E31EB92C26E1E400350082 /* reconnect-license */; };
@@ -86,7 +58,6 @@
 		D8F1A5B02C4A4EBC00931C00 /* ApplicationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F1A5AF2C4A4EBC00931C00 /* ApplicationModel.swift */; };
 		D8F1A5B82C4A4F8000931C00 /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8F1A5B72C4A4F8000931C00 /* Interact */; };
 		D8FD72732C3D192F0038DB17 /* sparkle-license in Resources */ = {isa = PBXBuildFile; fileRef = D8FD72722C3D192F0038DB17 /* sparkle-license */; };
-		D8FFE85F2C49F2FB001F7D8A /* TransfersWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFE85E2C49F2FB001F7D8A /* TransfersWindow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,18 +126,10 @@
 
 /* Begin PBXFileReference section */
 		D8068F6D2C4AFCE4004177F6 /* ReconnectCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ReconnectCore; sourceTree = "<group>"; };
-		D8068F712C4AFF29004177F6 /* BrowserWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindow.swift; sourceTree = "<group>"; };
 		D813FF142C26E869009CF0DC /* plptools-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "plptools-license"; sourceTree = "<group>"; };
-		D8184C462C253C59008FA79B /* ApplicationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationModel.swift; sourceTree = "<group>"; };
 		D820123E2DE1170200854FE9 /* HelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommands.swift; sourceTree = "<group>"; };
 		D83658B62C29596F00B45693 /* NavigationHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationHistoryTests.swift; sourceTree = "<group>"; };
 		D83658B82C298C4F00B45693 /* NavigationHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationHistory.swift; sourceTree = "<group>"; };
-		D83658BA2C29A09300B45693 /* HistoryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemView.swift; sourceTree = "<group>"; };
-		D83A78692C3C80C9000E8192 /* FileTypePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypePopover.swift; sourceTree = "<group>"; };
-		D83B4DDE2C2F9995003C3DC1 /* CheckForUpdatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesView.swift; sourceTree = "<group>"; };
-		D83B4DE02C2F99C3003C3DC1 /* CheckForUpdatesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckForUpdatesViewModel.swift; sourceTree = "<group>"; };
-		D83BD9742DE8E2370075902D /* AnimagedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimagedImage.swift; sourceTree = "<group>"; };
-		D83BD9762DE8F4B10075902D /* NSInstallerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSInstallerWindow.swift; sourceTree = "<group>"; };
 		D83BD9782DE914B20075902D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D84964D62C1BFCB600405656 /* Reconnect.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Reconnect.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D84964D92C1BFCB600405656 /* ReconnectApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectApp.swift; sourceTree = "<group>"; };
@@ -178,30 +141,16 @@
 		D84964F12C1BFCB700405656 /* ReconnectUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReconnectUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D84964F52C1BFCB700405656 /* ReconnectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectUITests.swift; sourceTree = "<group>"; };
 		D84964F72C1BFCB700405656 /* ReconnectUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		D8631DAA2C36867300344DC3 /* BrowserDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDetailView.swift; sourceTree = "<group>"; };
-		D8631DAE2C373A1600344DC3 /* TransferRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferRow.swift; sourceTree = "<group>"; };
-		D8631DB02C374B0A00344DC3 /* Transfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transfer.swift; sourceTree = "<group>"; };
-		D8631DB22C374B4400344DC3 /* TransfersModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransfersModel.swift; sourceTree = "<group>"; };
-		D8631DB42C374F8700344DC3 /* TransfersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransfersView.swift; sourceTree = "<group>"; };
 		D8631DB82C375F2400344DC3 /* WindowsPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowsPathTests.swift; sourceTree = "<group>"; };
 		D874B0CB2DEE4EAE008E938D /* SisInstallError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SisInstallError.swift; sourceTree = "<group>"; };
 		D876E60C2C22BAA9004A6881 /* libSystem.B.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libSystem.B.tbd; path = usr/lib/libSystem.B.tbd; sourceTree = SDKROOT; };
 		D876E60D2C22BAB9004A6881 /* libSystem.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libSystem.tbd; path = usr/lib/libSystem.tbd; sourceTree = SDKROOT; };
-		D886DA732C28CDAD00E84BDA /* BrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserView.swift; sourceTree = "<group>"; };
-		D886DA752C29343900E84BDA /* BrowserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserModel.swift; sourceTree = "<group>"; };
 		D89071882C4B01FC00C11DE8 /* screenshot-sis */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "screenshot-sis"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D890718A2C4B01FC00C11DE8 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		D8981E412DE3B03C003CBCF0 /* FileCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCommands.swift; sourceTree = "<group>"; };
 		D8981E432DE3B14D003CBCF0 /* SparkleCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleCommands.swift; sourceTree = "<group>"; };
-		D89B5E8D2C2AA8680014A5B6 /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
-		D8A8A8092DE1A093007A657B /* EditableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableText.swift; sourceTree = "<group>"; };
-		D8A8A80B2DE1A0B4007A657B /* EditableTextModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTextModel.swift; sourceTree = "<group>"; };
 		D8A8A80D2DE1A799007A657B /* apache-2.0-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "apache-2.0-license"; sourceTree = "<group>"; };
-		D8AB7ED22D0AA1130076E19F /* FileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReference.swift; sourceTree = "<group>"; };
-		D8AB9C332DEE3A1E0087F13E /* TextQueryInstallerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextQueryInstallerPage.swift; sourceTree = "<group>"; };
 		D8AB9C372DEE3EFC0087F13E /* WindowProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowProxy.swift; sourceTree = "<group>"; };
-		D8AC642B2D0D58910085306B /* ThumbnailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailView.swift; sourceTree = "<group>"; };
-		D8AC642D2D0D5B4A0085306B /* PixelImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelImage.swift; sourceTree = "<group>"; };
 		D8AD8B532C2379A10063A613 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8B1AC432E0F4C220084BFD5 /* ReconnectPreviews.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ReconnectPreviews.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8B1AC442E0F4C220084BFD5 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
@@ -212,14 +161,8 @@
 		D8B1AC622E0F88380084BFD5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PreviewViewController.xib; sourceTree = "<group>"; };
 		D8B1AC642E0F88380084BFD5 /* ReconnectPreviews.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReconnectPreviews.entitlements; sourceTree = "<group>"; };
 		D8D362982DE79CB000DDDD19 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		D8D3629A2DE7A23700DDDD19 /* InstallerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerPage.swift; sourceTree = "<group>"; };
 		D8D3E7A02C25410E003E696D /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
-		D8D5E3762DEB858100FEFBE1 /* ConfigurationQueryInstallerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationQueryInstallerPage.swift; sourceTree = "<group>"; };
 		D8DC357E2E0F37C100471D7D /* NavigationCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommands.swift; sourceTree = "<group>"; };
-		D8DE6DF82DF0DACE00E39CE2 /* ReplaceQueryInstallerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceQueryInstallerPage.swift; sourceTree = "<group>"; };
-		D8DECF452DE62874004DE55C /* InstallerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerView.swift; sourceTree = "<group>"; };
-		D8DECF472DE6288C004DE55C /* InstallerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerModel.swift; sourceTree = "<group>"; };
-		D8E2325B2DE1117400879866 /* FileConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileConverter.swift; sourceTree = "<group>"; };
 		D8E31EB42C26E10900350082 /* Licensable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licensable.swift; sourceTree = "<group>"; };
 		D8E31EB92C26E1E400350082 /* reconnect-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "reconnect-license"; sourceTree = "<group>"; };
 		D8E8B4FD2D1529E800405445 /* src */ = {isa = PBXFileReference; lastKnownFileType = folder; name = src; path = dependencies/opolua/src; sourceTree = "<group>"; };
@@ -230,11 +173,13 @@
 		D8F1A5A62C4A4C9C00931C00 /* ReconnectMenu.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReconnectMenu.entitlements; sourceTree = "<group>"; };
 		D8F1A5AF2C4A4EBC00931C00 /* ApplicationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationModel.swift; sourceTree = "<group>"; };
 		D8FD72722C3D192F0038DB17 /* sparkle-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "sparkle-license"; sourceTree = "<group>"; };
-		D8FFE85E2C49F2FB001F7D8A /* TransfersWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransfersWindow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		D823DB392E132DD500425703 /* Windows */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Windows; sourceTree = "<group>"; };
 		D83BD9672DE863220075902D /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Resources; sourceTree = "<group>"; };
+		D8EF0AB02E110B6700B566FC /* Model */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Model; sourceTree = "<group>"; };
+		D8EF0ACF2E110BB200B566FC /* Views */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Views; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -297,56 +242,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		D8068F702C4AFF05004177F6 /* Windows */ = {
-			isa = PBXGroup;
-			children = (
-				D83BD9762DE8F4B10075902D /* NSInstallerWindow.swift */,
-				D8068F712C4AFF29004177F6 /* BrowserWindow.swift */,
-				D8FFE85E2C49F2FB001F7D8A /* TransfersWindow.swift */,
-			);
-			path = Windows;
-			sourceTree = "<group>";
-		};
 		D80954632C4A57D400752BBC /* Views */ = {
 			isa = PBXGroup;
 			children = (
 				D8D3E7A02C25410E003E696D /* MainMenu.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		D8184C482C253C6F008FA79B /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				D8184C462C253C59008FA79B /* ApplicationModel.swift */,
-				D886DA752C29343900E84BDA /* BrowserModel.swift */,
-				D83B4DE02C2F99C3003C3DC1 /* CheckForUpdatesViewModel.swift */,
-				D8A8A80B2DE1A0B4007A657B /* EditableTextModel.swift */,
-				D8E2325B2DE1117400879866 /* FileConverter.swift */,
-				D8AB7ED22D0AA1130076E19F /* FileReference.swift */,
-				D8DECF472DE6288C004DE55C /* InstallerModel.swift */,
-				D8631DB02C374B0A00344DC3 /* Transfer.swift */,
-				D8631DB22C374B4400344DC3 /* TransfersModel.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		D8184C492C253D62008FA79B /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				D83BD9742DE8E2370075902D /* AnimagedImage.swift */,
-				D8631DAA2C36867300344DC3 /* BrowserDetailView.swift */,
-				D886DA732C28CDAD00E84BDA /* BrowserView.swift */,
-				D83B4DDE2C2F9995003C3DC1 /* CheckForUpdatesView.swift */,
-				D8A8A8092DE1A093007A657B /* EditableText.swift */,
-				D83A78692C3C80C9000E8192 /* FileTypePopover.swift */,
-				D83658BA2C29A09300B45693 /* HistoryItemView.swift */,
-				D8AC642D2D0D5B4A0085306B /* PixelImage.swift */,
-				D89B5E8D2C2AA8680014A5B6 /* Sidebar.swift */,
-				D8AC642B2D0D58910085306B /* ThumbnailView.swift */,
-				D8631DAE2C373A1600344DC3 /* TransferRow.swift */,
-				D8631DB42C374F8700344DC3 /* TransfersView.swift */,
-				D8AB9C352DEE3A5C0087F13E /* Installer */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -412,12 +311,12 @@
 				D849653D2C1D07AD00405656 /* Extensions */,
 				D8E31EB82C26E1CA00350082 /* Licenses */,
 				D8D362972DE79CB000DDDD19 /* Localizable.strings */,
-				D8184C482C253C6F008FA79B /* Model */,
+				D8EF0AB02E110B6700B566FC /* Model */,
 				D84964DF2C1BFCB700405656 /* Preview Content */,
 				D83BD9672DE863220075902D /* Resources */,
 				D822EA0F2C2BA305008A4BAA /* Utilities */,
-				D8184C492C253D62008FA79B /* Views */,
-				D8068F702C4AFF05004177F6 /* Windows */,
+				D8EF0ACF2E110BB200B566FC /* Views */,
+				D823DB392E132DD500425703 /* Windows */,
 			);
 			path = Reconnect;
 			sourceTree = "<group>";
@@ -474,18 +373,6 @@
 				D890718A2C4B01FC00C11DE8 /* Command.swift */,
 			);
 			path = ScreenshotSIS;
-			sourceTree = "<group>";
-		};
-		D8AB9C352DEE3A5C0087F13E /* Installer */ = {
-			isa = PBXGroup;
-			children = (
-				D8DE6DF82DF0DACE00E39CE2 /* ReplaceQueryInstallerPage.swift */,
-				D8D5E3762DEB858100FEFBE1 /* ConfigurationQueryInstallerPage.swift */,
-				D8D3629A2DE7A23700DDDD19 /* InstallerPage.swift */,
-				D8DECF452DE62874004DE55C /* InstallerView.swift */,
-				D8AB9C332DEE3A1E0087F13E /* TextQueryInstallerPage.swift */,
-			);
-			path = Installer;
 			sourceTree = "<group>";
 		};
 		D8AB9C362DEE3EF70087F13E /* Environment */ = {
@@ -569,7 +456,10 @@
 				D8B1AC512E0F4C220084BFD5 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				D823DB392E132DD500425703 /* Windows */,
 				D83BD9672DE863220075902D /* Resources */,
+				D8EF0AB02E110B6700B566FC /* Model */,
+				D8EF0ACF2E110BB200B566FC /* Views */,
 			);
 			name = Reconnect;
 			packageProductDependencies = (
@@ -807,44 +697,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				D820123F2DE1170700854FE9 /* HelpCommands.swift in Sources */,
-				D83A786A2C3C80C9000E8192 /* FileTypePopover.swift in Sources */,
-				D8068F722C4AFF29004177F6 /* BrowserWindow.swift in Sources */,
-				D8631DAF2C373A1600344DC3 /* TransferRow.swift in Sources */,
-				D83658BB2C29A09300B45693 /* HistoryItemView.swift in Sources */,
 				D8E31EB52C26E10900350082 /* Licensable.swift in Sources */,
-				D8E2325C2DE1117800879866 /* FileConverter.swift in Sources */,
-				D886DA742C28CDAD00E84BDA /* BrowserView.swift in Sources */,
 				D8DC357F2E0F37C700471D7D /* NavigationCommands.swift in Sources */,
-				D8AB7ED32D0AA1140076E19F /* FileReference.swift in Sources */,
-				D8A8A80A2DE1A095007A657B /* EditableText.swift in Sources */,
-				D8D5E3772DEB858500FEFBE1 /* ConfigurationQueryInstallerPage.swift in Sources */,
-				D83B4DE12C2F99C3003C3DC1 /* CheckForUpdatesViewModel.swift in Sources */,
-				D8A8A80C2DE1A0B6007A657B /* EditableTextModel.swift in Sources */,
-				D8AB9C342DEE3A230087F13E /* TextQueryInstallerPage.swift in Sources */,
-				D8FFE85F2C49F2FB001F7D8A /* TransfersWindow.swift in Sources */,
-				D8AC642E2D0D5B4D0085306B /* PixelImage.swift in Sources */,
 				D83658B92C298C4F00B45693 /* NavigationHistory.swift in Sources */,
 				D874B0CC2DEE4EB1008E938D /* SisInstallError.swift in Sources */,
-				D8DECF462DE62876004DE55C /* InstallerView.swift in Sources */,
-				D8631DAB2C36867400344DC3 /* BrowserDetailView.swift in Sources */,
-				D8184C472C253C59008FA79B /* ApplicationModel.swift in Sources */,
-				D83BD9772DE8F4B40075902D /* NSInstallerWindow.swift in Sources */,
-				D8631DB32C374B4400344DC3 /* TransfersModel.swift in Sources */,
 				D8981E422DE3B03F003CBCF0 /* FileCommands.swift in Sources */,
-				D8DECF482DE62890004DE55C /* InstallerModel.swift in Sources */,
-				D83BD9752DE8E2390075902D /* AnimagedImage.swift in Sources */,
-				D89B5E8E2C2AA8680014A5B6 /* Sidebar.swift in Sources */,
-				D886DA762C29343900E84BDA /* BrowserModel.swift in Sources */,
-				D8D3629B2DE7A23900DDDD19 /* InstallerPage.swift in Sources */,
 				D8981E442DE3B14F003CBCF0 /* SparkleCommands.swift in Sources */,
-				D83B4DDF2C2F9995003C3DC1 /* CheckForUpdatesView.swift in Sources */,
-				D8DE6DF92DF0DACF00E39CE2 /* ReplaceQueryInstallerPage.swift in Sources */,
-				D8631DB12C374B0A00344DC3 /* Transfer.swift in Sources */,
 				D84964DA2C1BFCB600405656 /* ReconnectApp.swift in Sources */,
-				D8631DB52C374F8700344DC3 /* TransfersView.swift in Sources */,
 				D83BD9792DE914B40075902D /* AppDelegate.swift in Sources */,
 				D8AB9C382DEE3EFE0087F13E /* WindowProxy.swift in Sources */,
-				D8AC642C2D0D58970085306B /* ThumbnailView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This should reduce the churn in the Xcode project when adding future changes.