### PR TITLE
feat: 📁 Customize the downloads folder

### DIFF
--- a/Reconnect/Model/ApplicationModel.swift
+++ b/Reconnect/Model/ApplicationModel.swift
@@ -36,13 +36,24 @@ class ApplicationModel: NSObject {
     }
 
     enum SettingsKey: String {
-        case selectedDevices
         case convertFiles
+        case downloadsURL
+        case selectedDevices
     }
 
     var convertFiles: Bool {
         didSet {
             keyedDefaults.set(convertFiles, forKey: .convertFiles)
+        }
+    }
+
+    var downloadsURL: URL {
+        didSet {
+            do {
+                try keyedDefaults.set(securityScopedURL: downloadsURL, forKey: .downloadsURL)
+            } catch {
+                print("Failed to save downloads path with error \(error).")
+            }
         }
     }
 
@@ -54,6 +65,7 @@ class ApplicationModel: NSObject {
 
     override init() {
         convertFiles = keyedDefaults.bool(forKey: .convertFiles, default: true)
+        downloadsURL = (try? keyedDefaults.securityScopedURL(forKey: .downloadsURL)) ?? .downloadsDirectory
         super.init()
         openMenuApplication()
         updaterController.startUpdater()

--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -333,9 +333,6 @@ class BrowserModel {
         }
     }
 
-    // TODO: Shouldn't be async.
-    // TODO: This could become the single item download.
-    // TODO: Perhaps push this into transfers or directly on the file server?
     private func _downloadDirectory(path: String, to downloadsURL: URL, convertFiles: Bool) async throws -> URL {
         let fileManager = FileManager.default
         let targetURL = downloadsURL.appendingPathComponent(path.lastWindowsPathComponent)
@@ -345,7 +342,6 @@ class BrowserModel {
         try fileManager.createDirectory(at: targetURL, withIntermediateDirectories: true)
 
         // Iterate over the recursive directory listing creating directories where necessary and downloading files.
-        // TODO: We can use this to improve progress reporting by pre-creating Progress objects for it.
         let files = try await self.fileServer.dir(path: path, recursive: true)
         for file in files {
             let relativePath = String(file.path.dropFirst(parentPath.count))

--- a/Reconnect/Model/TransfersModel.swift
+++ b/Reconnect/Model/TransfersModel.swift
@@ -80,27 +80,17 @@ class TransfersModel {
         return details
     }
 
-    // TODO: Consider exposing the downlaod filenames here for drag-and-drop consistency.
-
-    // TODO: Should the converter be injected or should this provide the filename proposal API?
-    // TODO: Injecting the converter isn't great since we want to be able to let the user choose interactively if
-    // possible.
     func download(from source: FileServer.DirectoryEntry,
-                  to destinationURL: URL? = nil,
-                  convertFiles: Bool) async throws -> URL {  // TODO: Plural?
-        let fileManager = FileManager.default
-
-        print("Downloading file '\(source.path)'...")
+                  to destinationURL: URL,
+                  convertFiles: Bool) async throws -> URL {
+        precondition(destinationURL.hasDirectoryPath)
+        print("Downloading file '\(source.path)' to '\(destinationURL.path)'...")
 
         let download = Transfer(item: .remote(source)) { transfer in
 
-            // Get the files into an array.
-            // For each file in the array. Ensure the destination directory exists. Transfer it.
-
-            // TODO: Consider always downloading to a temporary directory and then moving out in the last step.
-
-            // Iterate over the files:
-            let destinationURL = try (destinationURL ?? fileManager.createTemporaryDirectory())
+            // Perform the transfer updating the progress as we do so.
+            // This inner implementation takes responsibility of downloading to a temporary location and automatically
+            // converting files for us. Future implementations should allow for an inline interactive conversion prompt.
             let details = try await self._download(from: source,
                                                     to: destinationURL,
                                                     convertFiles: convertFiles) { progress, size in
@@ -121,7 +111,7 @@ class TransfersModel {
 
         // Double check that we received a local file. This could perhaps be an assertion.
         guard case .local(let url) = reference else {
-            throw ReconnectError.unknown // TODO
+            throw ReconnectError.invalidFileReference
         }
 
         return url
@@ -149,35 +139,4 @@ class TransfersModel {
         transfers.removeAll { !$0.isActive }
     }
 
-}
-
-extension TransfersModel {
-    
-    func addDemoData() {
-//        let remoteFile = FileServer.DirectoryEntry(path: "D:\\Screenshots\\Thoughts Splash Screen",
-//                                                   name: "Thoughts Splash Screen",
-//                                                   size: 2938478,
-//                                                   attributes: .normal,
-//                                                   modificationDate: .now,
-//                                                   uid1: .directFileStore,
-//                                                   uid2: .appDllDoc,
-//                                                   uid3: .sketch)
-//        let localFile = URL(fileURLWithPath: "/Users/jbmorley/Thoughts Screenshot.png")
-//        let error = ReconnectError.rfsvError(.init(rawValue: -37))
-//        transfers.append(Transfer(item: .remote(remoteFile), status: .waiting))
-//        transfers.append(Transfer(item: .remote(remoteFile), status: .failed(error)))
-//        transfers.append(Transfer(item: .local(localFile), status: .cancelled))
-//
-//        var min: UInt32 = 0
-//        transfers.append(Transfer(item: .remote(remoteFile)) { transfer in
-//            while min < remoteFile.size {
-//                try await Task.sleep(for: .milliseconds(1))
-//                min += 100
-//                transfer.setStatus(.active(min, remoteFile.size))
-//            }
-//            transfer.setStatus(.complete(Transfer.FileDetails(url: localFile, size: UInt64(remoteFile.size))))
-//        })
-
-    }
-    
 }

--- a/Reconnect/ReconnectApp.swift
+++ b/Reconnect/ReconnectApp.swift
@@ -54,6 +54,10 @@ struct ReconnectApp: App {
             .environment(appDelegate.transfersModel)
             .handlesExternalEvents(matching: [.programManager])
 
+        Settings {
+            SettingsView(applicationModel: appDelegate.applicationModel)
+        }
+
         About(repository: "inseven/reconnect", copyright: "Copyright © 2024-2025 Jason Morley") {
             Action("GitHub", url: .gitHub)
             Action("Discord", url: .discord)

--- a/Reconnect/Toolbars/FileToolbar.swift
+++ b/Reconnect/Toolbars/FileToolbar.swift
@@ -40,8 +40,9 @@ struct FileToolbar: CustomizableToolbarContent {
 
         ToolbarItem(id: "download") {
             Button {
-                browserModel.download(to: FileManager.default.downloadsDirectory,
-                                      convertFiles: applicationModel.convertFiles)
+                browserModel.download(to: applicationModel.downloadsURL,
+                                      convertFiles: applicationModel.convertFiles,
+                                      completion: { _ in })
             } label: {
                 Label("New Folder", systemImage: "square.and.arrow.down")
             }
@@ -67,7 +68,9 @@ struct FileToolbar: CustomizableToolbarContent {
                 Divider()
 
                 Button("Download") {
-                    browserModel.download(convertFiles: applicationModel.convertFiles)
+                    browserModel.download(to: applicationModel.downloadsURL,
+                                          convertFiles: applicationModel.convertFiles,
+                                          completion: { _ in })
                 }
                 .disabled(browserModel.isSelectionEmpty)
 

--- a/Reconnect/Views/FilePicker.swift
+++ b/Reconnect/Views/FilePicker.swift
@@ -1,0 +1,75 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2025 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import SwiftUI
+
+struct FilePickerOptions: OptionSet {
+    let rawValue: Int
+    static let canChooseFiles = Self(rawValue: 1 << 0)
+    static let canChooseDirectories = Self(rawValue: 1 << 1)
+    static let canCreateDirectories = Self(rawValue: 1 << 2)
+}
+
+struct FilePicker<Label: View>: View {
+
+    let label: Label
+    let options: FilePickerOptions
+
+    @Binding var url: URL
+
+    init(url: Binding<URL>, options: FilePickerOptions = [], @ViewBuilder label: () -> Label) {
+        self.label = label()
+        self.options = options
+        _url = url
+    }
+
+    var body: some View {
+        LabeledContent {
+            HStack {
+                Text(url.displayName)
+                Button("Select...") {
+                    let openPanel = NSOpenPanel()
+                    openPanel.canChooseFiles = options.contains(.canChooseFiles)
+                    openPanel.canChooseDirectories = options.contains(.canChooseDirectories)
+                    openPanel.canCreateDirectories = options.contains(.canCreateDirectories)
+                    openPanel.directoryURL = url.hasDirectoryPath ? url : url.deletingLastPathComponent()
+                    guard
+                        openPanel.runModal() ==  NSApplication.ModalResponse.OK,
+                        let url = openPanel.url
+                    else {
+                        return
+                    }
+                    self.url = url
+                }
+            }
+        } label: {
+            label
+        }
+    }
+
+}
+
+extension FilePicker where Label == Text {
+
+    init(_ titleKey: LocalizedStringKey, url: Binding<URL>, options: FilePickerOptions = []) {
+        self.label = Text(titleKey)
+        self.options = options
+        _url = url
+    }
+
+}

--- a/Reconnect/Views/SettingsView.swift
+++ b/Reconnect/Views/SettingsView.swift
@@ -1,0 +1,46 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2025 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import SwiftUI
+
+import Interact
+
+struct SettingsView: View {
+
+    var applicationModel: ApplicationModel
+
+    @ObservedObject var application = Application.shared
+
+    init(applicationModel: ApplicationModel) {
+        self.applicationModel = applicationModel
+    }
+
+    var body: some View {
+        @Bindable var applicationModel = applicationModel
+        Form {
+            Section("Downloads") {
+                FilePicker("Destination",
+                           url: $applicationModel.downloadsURL,
+                           options: [.canChooseDirectories, .canCreateDirectories])
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 400, height: 400)
+    }
+
+}

--- a/Reconnect/Views/TransfersView.swift
+++ b/Reconnect/Views/TransfersView.swift
@@ -53,12 +53,6 @@ struct TransfersView: View {
                     
                     Spacer()
 
-#if DEBUG
-                    Button("Add Demo Data") {
-                        transfersModel.addDemoData()
-                    }
-#endif
-
                     Button("Clear") {
                         transfersModel.clear()
                         if transfersModel.transfers.isEmpty {

--- a/Reconnect/Windows/BrowserWindow.swift
+++ b/Reconnect/Windows/BrowserWindow.swift
@@ -32,7 +32,8 @@ struct BrowserWindow: Scene {
     init(applicationModel: ApplicationModel, transfersModel: TransfersModel) {
         self.applicationModel = applicationModel
         self.transfersModel = transfersModel
-        _browserModel = State(initialValue: BrowserModel(transfersModel: transfersModel))
+        _browserModel = State(initialValue: BrowserModel(applicationModel: applicationModel,
+                                                         transfersModel: transfersModel))
     }
 
     var body: some Scene {

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/FileManager.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/FileManager.swift
@@ -24,12 +24,12 @@ extension FileManager {
         return urls(for: .downloadsDirectory, in: .userDomainMask)[0]
     }
 
-    public func temporaryURL() -> URL {
-        return temporaryDirectory.appendingPathComponent((UUID().uuidString))
+    public func temporaryURL(isDirectory: Bool = false) -> URL {
+        return temporaryDirectory.appendingPathComponent((UUID().uuidString), isDirectory: isDirectory)
     }
 
     public func createTemporaryDirectory() throws -> URL {
-        let temporaryURL = temporaryURL()
+        let temporaryURL = temporaryURL(isDirectory: true)
         try createDirectory(at: temporaryURL, withIntermediateDirectories: true)
         return temporaryURL
     }

--- a/ReconnectCore/Sources/ReconnectCore/Model/ReconnectError.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Model/ReconnectError.swift
@@ -27,6 +27,7 @@ public enum ReconnectError: Error {
     case imageSaveError
     case invalidLocalization
     case invalidSisFile
+    case invalidFileReference
 }
 
 extension ReconnectError: LocalizedError {
@@ -45,6 +46,8 @@ extension ReconnectError: LocalizedError {
             return "Badly formatted localized text."
         case .invalidSisFile:
             return "Invalid SIS file."
+        case .invalidFileReference:
+            return "Invalid file reference."
         }
     }
 


### PR DESCRIPTION
This change significantly tightens up the internal file transfer to ensure we can consistently inject the user-configured downloads directory and subsequently fixes folder drag-and-drop downloads.