### PR TITLE
fix: 🧹 Remove unnecessary file menu toolbar item

### DIFF
--- a/Reconnect/Toolbars/FileToolbar.swift
+++ b/Reconnect/Toolbars/FileToolbar.swift
@@ -58,34 +58,6 @@ struct FileToolbar: CustomizableToolbarContent {
             .disabled(browserModel.isSelectionEmpty)
         }
 
-        ToolbarItem(id: "action") {
-            Menu {
-
-                Button("New Folder") {
-                    browserModel.newFolder()
-                }
-
-                Divider()
-
-                Button("Download") {
-                    browserModel.download(to: applicationModel.downloadsURL,
-                                          convertFiles: applicationModel.convertFiles,
-                                          completion: { _ in })
-                }
-                .disabled(browserModel.isSelectionEmpty)
-
-                Divider()
-
-                Button("Delete") {
-                    browserModel.delete()
-                }
-                .disabled(browserModel.isSelectionEmpty)
-
-            } label: {
-                Label("Action", systemImage: "ellipsis.circle")
-            }
-        }
-
     }
 
 }


### PR DESCRIPTION
The file menu toolbar item duplicates functionality available in other toolbar items and clutters the main toolbar unnecessarily.