### PR TITLE
fix: 🏃 Add downloads to the transfers window immediately

### DIFF
--- a/Reconnect/Model/BrowserModel.swift
+++ b/Reconnect/Model/BrowserModel.swift
@@ -311,14 +311,21 @@ class BrowserModel {
 
         Task {
             do {
-                var results: [URL] = []
-                for file in files {
-                    let url = try await transfersModel.download(from: file,
-                                                                to: destinationURL,
-                                                                convertFiles: convertFiles)
-                    results.append(url)
+                let urls = try await withThrowingTaskGroup(of: URL.self) { [transfersModel] group in
+                    for file in files {
+                        group.addTask {
+                            return try await transfersModel.download(from: file,
+                                                                     to: destinationURL,
+                                                                     convertFiles: convertFiles)
+                        }
+                    }
+                    var results: [URL] = []
+                    for try await url in group {
+                        results.append(url)
+                    }
+                    return results
                 }
-                completion(.success(results))
+                completion(.success(urls))
             } catch {
                 completion(.failure(error))
             }


### PR DESCRIPTION
An earlier change introduced a regression which meant downloads didn’t get added to the transfers window until they were about to start, making it impossible to tell if they’d been successfully queued or not.