### PR TITLE
fix: 📏 Set a minimum size for installer pages

### DIFF
--- a/Reconnect/Views/Installer/InstallerPage.swift
+++ b/Reconnect/Views/Installer/InstallerPage.swift
@@ -18,6 +18,12 @@
 
 import SwiftUI
 
+fileprivate struct LayoutMetrics {
+    static let minWidth: CGFloat = 600
+    static let minHeight: CGFloat = 400
+}
+
+
 @MainActor
 struct InstallerPage<Content: View, Actions: View>: View {
 
@@ -67,6 +73,7 @@ struct InstallerPage<Content: View, Actions: View>: View {
             }
             .padding()
         }
+        .frame(minWidth: LayoutMetrics.minWidth, minHeight: LayoutMetrics.minHeight)
     }
 
 }


### PR DESCRIPTION
Small installer pages don’t appear to size correctly pre-Sequoia. This change ensures they have a minimum size.
