### PR TITLE
ci: Improve website build reliability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,8 @@ jobs:
       run: scripts/install-dependencies.sh
 
     - name: Build website
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         scripts/build-website.sh
         chmod -v -R +rX "_site/"


### PR DESCRIPTION
This change makes use of the `GITHUB_TOKEN` environment variable when fetching the latest release URL from GitHub and also catches up to a new version of `build-tools` with support for retries when encountering the GitHub API rate limits.
