### PR TITLE
fix: 📦 Improve SIS file Quick Look preview reliability

### DIFF
--- a/Reconnect.xcodeproj/project.pbxproj
+++ b/Reconnect.xcodeproj/project.pbxproj
@@ -106,6 +106,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D85414062E29A5E9009DEC42 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"reconnect-tools/Reconnect Tools.pkg",
+				"reconnect-tools/screenshot.exe",
+				ReconnectTools.sis,
+			);
+			target = D8B1AC422E0F4C220084BFD5 /* ReconnectPreviews */;
+		};
 		D891AE982E1373CE009EC465 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -144,7 +153,7 @@
 		D891AE6B2E13726F009EC465 /* ReconnectMenu */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ReconnectMenu; sourceTree = "<group>"; };
 		D891AE922E1373CE009EC465 /* ReconnectPreviews */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D891AE982E1373CE009EC465 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ReconnectPreviews; sourceTree = "<group>"; };
 		D891AEDA2E13741B009EC465 /* Reconnect */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D891AF102E13741B009EC465 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, D891AF112E13741B009EC465 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Reconnect; sourceTree = "<group>"; };
-		D8A75B552E18AF8A007B6DBA /* tools */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D8A75B5C2E18AFA2007B6DBA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = tools; sourceTree = "<group>"; };
+		D8A75B552E18AF8A007B6DBA /* tools */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D8A75B5C2E18AFA2007B6DBA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, D85414062E29A5E9009DEC42 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = tools; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -880,7 +889,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.jbmorley.reconnect.apps.apple.previews;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -909,7 +917,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = uk.co.jbmorley.reconnect.apps.apple.previews;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Reconnect/Info.plist
+++ b/Reconnect/Info.plist
@@ -18,6 +18,18 @@
 			<key>NSDocumentClass</key>
 			<string></string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Psion Software Install (OpoLua)</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.opolua.sis</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
@@ -37,7 +49,32 @@
 	<key>SUPublicEDKey</key>
 	<string>3EjNyhaYtMraXwX9DnIazXbJe4worl2Bktkt8VrZXZk=</string>
 	<key>UTExportedTypeDeclarations</key>
+	<array/>
+	<key>UTImportedTypeDeclarations</key>
 	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Psion Software Install</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>org.opolua.sis</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sis</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/octet-stream</string>
+				</array>
+			</dict>
+		</dict>
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>

--- a/Reconnect/Model/ApplicationModel.swift
+++ b/Reconnect/Model/ApplicationModel.swift
@@ -101,7 +101,7 @@ class ApplicationModel: NSObject {
         openPanel.canChooseDirectories = false
         openPanel.canCreateDirectories = false
         openPanel.allowsMultipleSelection = false
-        openPanel.allowedContentTypes = [.sis]
+        openPanel.allowedContentTypes = [.sis, .sisOpoLua]
         guard openPanel.runModal() ==  NSApplication.ModalResponse.OK else {
             return
         }

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/UTType.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/UTType.swift
@@ -24,4 +24,8 @@ extension UTType {
         return UTType(exportedAs: "com.psion.sis", conformingTo: .data)
     }
 
+    public static var sisOpoLua: Self {
+        return UTType(exportedAs: "org.opolua.sis", conformingTo: .data)
+    }
+
 }

--- a/ReconnectPreviews/Info.plist
+++ b/ReconnectPreviews/Info.plist
@@ -11,6 +11,7 @@
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>com.psion.sis</string>
+				<string>org.opolua.sis</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<false/>


### PR DESCRIPTION
This makes a couple of small but important changes to improve SIS file Quick Look preview reliability:

- import instead of export SIS file types
- support `org.opolua.sis` as well as `com.psion.sis` for users with earlier builds of OpoLua
- support macOS Sonoma