### PR TITLE
docs[website]: Improve the Getting Started documentation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,6 +10,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-image-size", "~> 1.2"
   gem "jekyll-toc"
+  gem 'jekyll-gfm-admonitions'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
+    cssminify (1.0.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -40,6 +41,10 @@ GEM
       jekyll (>= 3.0, < 5.x)
     jekyll-feed (0.16.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-gfm-admonitions (1.2.0)
+      cssminify (~> 1.0)
+      jekyll (>= 3.0, < 5.0)
+      octicons (~> 19.8)
     jekyll-image-size (1.2.1)
       fastimage (>= 1.8)
       jekyll (>= 3.7)
@@ -63,6 +68,7 @@ GEM
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    octicons (19.15.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (5.0.0)
@@ -90,6 +96,7 @@ DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-environment-variables
   jekyll-feed (~> 0.12)
+  jekyll-gfm-admonitions
   jekyll-image-size (~> 1.2)
   jekyll-toc
   theme!

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,12 +29,21 @@ footer:
     href: https://jbmorley.co.uk/software/
 
 plugins:
-  - jekyll-feed
   - jekyll-environment-variables
-  - jekyll-toc
+  - jekyll-feed
+  - jekyll-gfm-admonitions
   - jekyll-image-size
+  - jekyll-toc
 destination: ../_site
+
+toc:
+  ordered_list: true
 
 defaults:
   - values:
       layout: "page"
+  - scope:
+      path: "docs"
+    values:
+      layout: "documentation"
+      toc: true

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -3,16 +3,30 @@ title: Getting Started
 layout: documentation
 ---
 
-# Getting Started
+# Hardware
 
-## Hardware
+In order to connect your Psion to your Mac, you'll need a couple of bits of hardware: an RS232 adapter, and a suitable link cable.
 
-In order to connect your Psion to your Mac, you'll need a couple of bits of hardware.
+## RS232 Adapter
 
-- RS232 link cable
-    - [3Link for Psion Series 3, and 3a](https://psionex.co.uk/en/product/pda/series3/adapters-cables-modems/c-3l-complete.html)
-    - [Honda cable Psion Series 3c, 3mx, 5, 5mx, 7, and netBook](https://psionex.co.uk/en/product/pda/netbook/adapters-cables-modems/s5mx-rs232-link.html)
-- [FTDI RS232 USB-C adapter](https://www.amazon.com/dp/B09WJS26WX)
+RS232 adapters using an [FTDI](https://ftdichip.com) chipset are the most reliable on macOS and are recommended. [This one](https://www.amazon.com/dp/B09WJS26WX) from Amazon US seems to work well.
 
+> [!IMPORTANT]
+> [Prolific](https://www.prolific.com.tw/) adapters can be made to work, but the default drivers that ship by default with macOS are unreliable so you'll need to install the [official drivers](https://apps.apple.com/gb/app/pl2303-serial/id1624835354).
 
-[^1]: Commonly known as a 'honda' cable as Honda manufactured the connectors.
+[Alex Brown](https://oldbytes.space/@thelastpsion) has done some pretty rigorous testing of different adapters which you can find on his [Hackaday blog](https://hackaday.io/project/161291-the-last-psion/log/222358-usb-rs232-shenanigans-updated-2025-05-28).
+
+## Link Cable
+
+The link cable you need depends on the type of Psion you have. Unfortunately these can be a little expensive now, but [Psionex](https://psionex.co.uk) still have stock at relatively competitive prices.
+
+### Series 3 and 3a
+
+- [3Link for Psion Series 3, and 3a](https://psionex.co.uk/en/product/pda/series3/adapters-cables-modems/c-3l-complete.html)
+
+### Series 3c, 3mx, 5, 5mx, 7, and netBook
+
+- [Link cable Psion Series 3c, 3mx, 5, 5mx, 7, and netBook](https://psionex.co.uk/en/product/pda/netbook/adapters-cables-modems/s5mx-rs232-link.html)
+
+> [!NOTE]
+> These are commonly known as 'Honda' cables as Honda manufactured the original connectors.


### PR DESCRIPTION
This also catches up to the latest version of the showcase theme with improved documentation layout, TOC, and support for GitHub-flavor admonitions.