### PR TITLE
fix: ❌ Quit the browser app when quitting the menu bar app

### DIFF
--- a/Reconnect/Model/ApplicationModel.swift
+++ b/Reconnect/Model/ApplicationModel.swift
@@ -113,28 +113,26 @@ class ApplicationModel: NSObject {
     }
 
     private func openMenuApplication() {
+#if !DEBUG
         terminateAnyIncompatibleMenuBarApplications()
+#else
+        // In debug, we always restart the menu bar applicaiton to ease development.
+        terminateRunningMenuApplications()
+#endif
         let embeddedAppURL = Bundle.main.url(forResource: "Reconnect Menu", withExtension: "app")!
-        let openConfiguraiton = NSWorkspace.OpenConfiguration()
-        NSWorkspace.shared.openApplication(at: embeddedAppURL, configuration: openConfiguraiton)
+        let openConfiguration = NSWorkspace.OpenConfiguration()
+        openConfiguration.allowsRunningApplicationSubstitution = false
+        NSWorkspace.shared.openApplication(at: embeddedAppURL, configuration: openConfiguration)
     }
 
     nonisolated private func terminateRunningMenuApplications() {
-        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: "uk.co.jbmorley.reconnect.apps.apple.menu")
-        for app in runningApps {
-            app.terminate()
-        }
-        for app in runningApps {
-            while !app.isTerminated {
-                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-            }
-        }
+        NSRunningApplication.terminateRunningApplications(withBundleIdentifier: .menuApplicationBundleIdentifier)
     }
 
     private func terminateAnyIncompatibleMenuBarApplications() {
         let embeddedAppURL = Bundle.main.url(forResource: "Reconnect Menu", withExtension: "app")!
         let expectedHash = getCDHashForBinary(at: embeddedAppURL)
-        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: "uk.co.jbmorley.reconnect.apps.apple.menu")
+        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: .menuApplicationBundleIdentifier)
         for app in runningApps {
             let hash = getCDHashForPID(app.processIdentifier)
             guard hash != expectedHash else {

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/NSRunningApplication.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/NSRunningApplication.swift
@@ -1,0 +1,35 @@
+// Reconnect -- Psion connectivity for macOS
+ //
+ // Copyright (C) 2024-2025 Jason Morley
+ //
+ // This program is free software; you can redistribute it and/or modify
+ // it under the terms of the GNU General Public License as published by
+ // the Free Software Foundation; either version 2 of the License, or
+ // (at your option) any later version.
+ //
+ // This program is distributed in the hope that it will be useful,
+ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ // GNU General Public License for more details.
+ //
+ // You should have received a copy of the GNU General Public License
+ // along with this program; if not, write to the Free Software
+ // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import AppKit
+
+extension NSRunningApplication {
+
+    public static func terminateRunningApplications(withBundleIdentifier bundleIdentifier: String) {
+        let runningApps = runningApplications(withBundleIdentifier: bundleIdentifier)
+        for app in runningApps {
+            app.terminate()
+        }
+        for app in runningApps {
+            while !app.isTerminated {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            }
+        }
+    }
+
+}

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
@@ -26,6 +26,9 @@ public extension String {
     static let screenshotToolPath = "C:\\System\\Reconnect\\screenshot.exe"
     static let windowsPathSeparator = "\\"
 
+    static let browserApplicationBundleIdentifier = "uk.co.jbmorley.reconnect.apps.apple"
+    static let menuApplicationBundleIdentifier = "uk.co.jbmorley.reconnect.apps.apple.menu"
+
     var deletingLastWindowsPathComponent: String {
         return windowsPathComponents
             .dropLast()

--- a/ReconnectMenu/Model/ApplicationModel.swift
+++ b/ReconnectMenu/Model/ApplicationModel.swift
@@ -94,6 +94,11 @@ class ApplicationModel: NSObject {
     }
 
     @MainActor func quit() {
+        // We terminate any running instances of the main Reconnect app as it doesn't make sense for them to run
+        // standalone if there's nothing running the PLP sessions.
+        // In the future, we should look to inverting our bundle and process architecture and making the menu bar app
+        // the parent.
+        NSRunningApplication.terminateRunningApplications(withBundleIdentifier: .browserApplicationBundleIdentifier)
         NSApplication.shared.terminate(nil)
     }
 


### PR DESCRIPTION
The menu bar app runs the Psion connection so it doesn't make sense to keep the browser window open when quitting the menu bar app.