### PR TITLE
refactor: Update `NSRunningApplication.terminateRunningApplications`

### DIFF
--- a/Reconnect/Model/ApplicationModel.swift
+++ b/Reconnect/Model/ApplicationModel.swift
@@ -125,8 +125,9 @@ class ApplicationModel: NSObject {
         NSWorkspace.shared.openApplication(at: embeddedAppURL, configuration: openConfiguration)
     }
 
-    nonisolated private func terminateRunningMenuApplications() {
-        NSRunningApplication.terminateRunningApplications(withBundleIdentifier: .menuApplicationBundleIdentifier)
+    nonisolated func terminateRunningMenuApplications() {
+        NSRunningApplication.terminateRunningApplications(bundleIdentifier: .menuApplicationBundleIdentifier,
+                                                          waitForCompletion: true)
     }
 
     private func terminateAnyIncompatibleMenuBarApplications() {

--- a/ReconnectCore/Sources/ReconnectCore/Extensions/NSRunningApplication.swift
+++ b/ReconnectCore/Sources/ReconnectCore/Extensions/NSRunningApplication.swift
@@ -20,10 +20,13 @@ import AppKit
 
 extension NSRunningApplication {
 
-    public static func terminateRunningApplications(withBundleIdentifier bundleIdentifier: String) {
+    public static func terminateRunningApplications(bundleIdentifier: String, waitForCompletion: Bool) {
         let runningApps = runningApplications(withBundleIdentifier: bundleIdentifier)
         for app in runningApps {
             app.terminate()
+        }
+        guard waitForCompletion else {
+            return
         }
         for app in runningApps {
             while !app.isTerminated {


### PR DESCRIPTION
This change adds an explicit `waitForCompletion` parameter to allow callers to decide behavior.