### PR TITLE
Catch up OpoLua and fix no serial devices error text

### DIFF
--- a/Reconnect/Extensions/SisInstallError.swift
+++ b/Reconnect/Extensions/SisInstallError.swift
@@ -31,6 +31,8 @@ extension Sis.InstallError: @retroactive LocalizedError {
              return LocalizedEpoc32ErrorCode(code)
          case .internalError(let message):
              return message
+         case .isStub:
+             return "Invalid SIS file"
          }
      }
 

--- a/ReconnectCore/Sources/ReconnectCore/XPC/SerialDevice.swift
+++ b/ReconnectCore/Sources/ReconnectCore/XPC/SerialDevice.swift
@@ -89,7 +89,7 @@ public class SerialDevice: NSObject, NSSecureCoding, Identifiable {
 extension SerialDevice {
 
     public var isUsable: Bool {
-        return isAvailable && configuration.baudRate != 0
+        return isAvailable && configuration.isEnabled
     }
 
 }


### PR DESCRIPTION
This catches up to the latest version of OpoLua with some small parsing and lifecycle improvements.