### PR TITLE
fix: 🪶 Use program names in the software index version list

### DIFF
--- a/Reconnect/Software Index/Views/ProgramView.swift
+++ b/Reconnect/Software Index/Views/ProgramView.swift
@@ -87,7 +87,7 @@ struct ProgramView: View {
                             HStack(alignment: .center) {
                                 IconView(url: item.iconURL)
                                 VStack(alignment: .leading) {
-                                    Text(item.filename)
+                                    Text(item.name)
                                     Text(item.referenceString)
                                         .font(.footnote)
                                 }


### PR DESCRIPTION
This matches the behaviour on the website and is more useful than filenames in helping users select which version they wish to install.