### PR TITLE
fix: 📂 Move ‘open enclosing folder’ toolbar item after forward / back

### DIFF
--- a/Reconnect/Toolbars/NavigationToolbar.swift
+++ b/Reconnect/Toolbars/NavigationToolbar.swift
@@ -30,15 +30,6 @@ struct NavigationToolbar: CustomizableToolbarContent {
 
     var body: some CustomizableToolbarContent {
 
-        ToolbarItem(id: "open-enclosing-folder", placement: .navigation) {
-            Button {
-                parentNavigable?.navigateToParent()
-            } label: {
-                Label("Enclosing Folder", systemImage: "arrow.turn.left.up")
-            }
-            .disabled(!(parentNavigable?.canNavigateToParent ?? false))
-        }
-
         ToolbarItem(id: "navigation", placement: .navigation) {
             LabeledContent {
                 HStack(spacing: 8) {
@@ -84,6 +75,15 @@ struct NavigationToolbar: CustomizableToolbarContent {
                 Text("Back/Forward")
             }
 
+        }
+
+        ToolbarItem(id: "open-enclosing-folder", placement: .navigation) {
+            Button {
+                parentNavigable?.navigateToParent()
+            } label: {
+                Label("Enclosing Folder", systemImage: "arrow.turn.left.up")
+            }
+            .disabled(!(parentNavigable?.canNavigateToParent ?? false))
         }
 
     }


### PR DESCRIPTION
The ‘open enclosing folder’ action applies to the current detail view, while the back / forward buttons apply to the whole app. It makes sense they would be leading in the hierarchy.

Thanks to @kapfab for this suggestion.