### PR TITLE
fix: 😶‍🌫️ Prepare for the new optional UID in the Software Index API

### DIFF
--- a/Reconnect/Software Index/API/Release.swift
+++ b/Reconnect/Software Index/API/Release.swift
@@ -20,13 +20,14 @@
 
 import Foundation
 
-public struct Release: Codable, Identifiable, Hashable {
+public struct Release: Codable, Hashable {
 
-    public var id: String {
-        return uid + referenceString
+    public var uniqueId: String {
+        return id + referenceString
     }
 
-    public let uid: String
+    public let id: String
+    public let uid: String?
     public let kind: Kind
     public let name: String
     let icon: SoftwareIndexImage?

--- a/Reconnect/Software Index/Views/ProgramView.swift
+++ b/Reconnect/Software Index/Views/ProgramView.swift
@@ -88,7 +88,7 @@ struct ProgramView: View {
                 ForEach(program.versions) { version in
                     Section {
                         ForEach(version.variants) { variant in
-                            ForEach(variant.items) { item in
+                            ForEach(variant.items, id: \.uniqueId) { item in
                                 HStack(alignment: .center) {
                                     IconView(url: item.iconURL)
                                     VStack(alignment: .leading) {


### PR DESCRIPTION
This is is preparatory work to ensure Reconnect is robust to the coming optional UID in the Software Index API.