### PR TITLE
fix: 🥲 Catch up to the new Software Index APIs

### DIFF
--- a/Reconnect/Software Index/API/Program.swift
+++ b/Reconnect/Software Index/API/Program.swift
@@ -22,11 +22,7 @@ import Foundation
 
 struct Program: Codable, Identifiable, Hashable {
 
-    var id: String {
-        return uid
-    }
-
-    let uid: String
+    let id: String
     let name: String
     let icon: SoftwareIndexImage?
     let versions: [Version]

--- a/Reconnect/Software Index/Model/LibraryModel.swift
+++ b/Reconnect/Software Index/Model/LibraryModel.swift
@@ -101,7 +101,7 @@ protocol LibraryModelDelegate: AnyObject {
                 guard versions.count > 0 else {
                     return nil
                 }
-                return Program(uid: program.uid,
+                return Program(id: program.id,
                                name: program.name,
                                icon: program.icon,
                                versions: versions,


### PR DESCRIPTION
Looks like I missed a property rename when I prepared for the API updates.