### PR TITLE
fix: ℹ️ Add an icon to the about menu item

### DIFF
--- a/Reconnect/Commands/HelpCommands.swift
+++ b/Reconnect/Commands/HelpCommands.swift
@@ -1,0 +1,45 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2025 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import SwiftUI
+
+public struct HelpCommands: Commands {
+
+    @Environment(\.openURL) private var openURL
+
+    public var body: some Commands {
+
+        CommandGroup(replacing: .help) {
+
+            Button {
+                openURL(.donate)
+            } label: {
+                Label("Donate", systemImage: "globe")
+            }
+
+            Button {
+                openURL(.software)
+            } label: {
+                Label("More Software by Jason Morley", systemImage: "globe")
+            }
+
+        }
+
+    }
+
+}

--- a/Reconnect/Windows/BrowserWindow.swift
+++ b/Reconnect/Windows/BrowserWindow.swift
@@ -43,6 +43,7 @@ struct BrowserWindow: Scene {
         }
         .commands {
             SparkleCommands(applicationModel: applicationModel)
+            HelpCommands()
             FileCommands()
             RefreshCommands()
             SidebarCommands()


### PR DESCRIPTION
This change catches up to the latest version of Diligence which also automatically adds most help menu items, allowing us to simplify `HelpCommands`.