### PR TITLE
fix: 📦 Allow installs on EPOC16 devices

### DIFF
--- a/Reconnect/Model/DeviceModel.swift
+++ b/Reconnect/Model/DeviceModel.swift
@@ -41,17 +41,20 @@ class DeviceModel: Identifiable, Equatable {
         return lhs.id != rhs.id
     }
 
-    var machineType: RemoteCommandServicesClient.MachineType = .unknown
-    var machineInfo: RemoteCommandServicesClient.MachineInfo? = nil
-    var drives: [FileServer.DriveInfo] = []
-    var isCapturingScreenshot: Bool = false
+    @MainActor var machineType: RemoteCommandServicesClient.MachineType = .unknown
+    @MainActor var machineInfo: RemoteCommandServicesClient.MachineInfo? = nil
+    @MainActor var drives: [FileServer.DriveInfo] = []
+    @MainActor var isCapturingScreenshot: Bool = false
 
+    @MainActor
     var internalDrive: FileServer.DriveInfo? {
+        dispatchPrecondition(condition: .onQueue(.main))
         return drives.first { driveInfo in
             return driveInfo.mediaType == .ram
         }
     }
 
+    @MainActor
     var installDirectory: String? {
         switch machineType {
         case .unknown, .pc, .mc, .hc, .winC:

--- a/Reconnect/Model/ProgramManagerModel.swift
+++ b/Reconnect/Model/ProgramManagerModel.swift
@@ -77,7 +77,10 @@ class ProgramManagerModel: Runnable, @unchecked Sendable {
     private func syncQueue_reload() {
         dispatchPrecondition(condition: .onQueue(syncQueue))
         do {
-            guard let installDirectory = deviceModel.installDirectory else {
+            let installDirectory = DispatchQueue.main.sync {
+                return deviceModel.installDirectory
+            }
+            guard let installDirectory else {
                 print("Unable to determine device install directory.")
                 return
             }

--- a/Reconnect/Views/Installer/ConfigurationQueryInstallerPage.swift
+++ b/Reconnect/Views/Installer/ConfigurationQueryInstallerPage.swift
@@ -23,7 +23,7 @@ import OpoLuaCore
 @MainActor
 struct ConfigurationQueryInstallerPage: View {
 
-    @State var driveSelection: String = "C"
+    @State var driveSelection: String
     @State var languageSelection: String
 
     let query: InstallerModel.ConfigurationQuery
@@ -32,6 +32,7 @@ struct ConfigurationQueryInstallerPage: View {
     init(query: InstallerModel.ConfigurationQuery) {
         self.query = query
         self.languages = query.sis.languages
+        self.driveSelection = query.defaultDrive
         self.languageSelection = query.defaultLanguage
     }
 
@@ -62,10 +63,10 @@ struct ConfigurationQueryInstallerPage: View {
                 .frame(maxWidth: InstallerView.LayoutMetrics.maximumContentWidth)
             } actions: {
                 Button("Cancel", role: .destructive) {
-                    query.resume(.userCancelled)
+                    query.cancel()
                 }
                 Button("Continue") {
-                    query.resume(.install(.init(drive: driveSelection, stubDir: nil, language: languageSelection)))
+                    query.continue(drive: driveSelection, language: languageSelection)
                 }
                 .keyboardShortcut(.defaultAction)
             }


### PR DESCRIPTION
This change updates the installer to read the currently connected device and tailors the install to match its OS. While there were never any SIS files authored for EPOC16 devices, there’s no reason the file format can’t to package apps for these older devices, and this change goes some way to unlocking that by ensuring they behave sensibly on EPOC16 (as well as the expected EPOC32). In the future we’re planning to explicitly version EPOC16 SIS files and guard against using installers for the wrong platform but, until then, anything should install (but it probably won’t work).