### PR TITLE
fix: ⤴️ Ensure file operations work after navigating to a parent folder

### DIFF
--- a/Reconnect/Model/DirectoryModel.swift
+++ b/Reconnect/Model/DirectoryModel.swift
@@ -293,7 +293,9 @@ extension DirectoryModel: ParentNavigable {
     }
 
     func navigateToParent() {
-        navigate(to: path.deletingLastWindowsPathComponent)
+        navigate(to: path
+            .deletingLastWindowsPathComponent
+            .ensuringTrailingWindowsPathSeparator())
     }
 
 }


### PR DESCRIPTION
Ensure there’s a trailing forward slash when navigating to parent folders.