### PR TITLE
refactor: Move `Error` extension into a separate file

### DIFF
--- a/Reconnect/Extensions/Error.swift
+++ b/Reconnect/Extensions/Error.swift
@@ -1,0 +1,35 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2026 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import OpoLuaCore
+import ReconnectCore
+
+extension Error {
+
+    var isCancel: Bool {
+        if let error = self as? Sis.InstallError, case .userCancelled = error {
+            return true
+        } else if let error = self as? PLPToolsError, case .cancelled = error {
+            return true
+        } else if let error = self as? ReconnectError, case .cancelled = error {
+            return true
+        }
+        return false
+    }
+
+}

--- a/Reconnect/Views/Installer/InstallerView.swift
+++ b/Reconnect/Views/Installer/InstallerView.swift
@@ -21,18 +21,6 @@ import SwiftUI
 import Interact
 import OpoLuaCore
 
-extension Error {
-
-    var isCancel: Bool {
-        if let error = self as? Sis.InstallError,
-           case .userCancelled = error {
-            return true
-        }
-        return false
-    }
-
-}
-
 @MainActor
 struct InstallerView: View {
 


### PR DESCRIPTION
This moves the `Error` extension into a separate file and adds support for detecting other cancellation errors.