### PR TITLE
refactor: Rename `NavigationHistory` to `NavigationModel`

### DIFF
--- a/Reconnect/Commands/NavigationCommands.swift
+++ b/Reconnect/Commands/NavigationCommands.swift
@@ -20,7 +20,7 @@ import SwiftUI
 
 public struct NavigationCommands: Commands {
 
-    @Environment(NavigationHistory.self) private var navigationHistory
+    @Environment(NavigationModel.self) private var navigationModel
 
     @FocusedObject private var parentNavigableProxy: ParentNavigableProxy?
 
@@ -29,20 +29,20 @@ public struct NavigationCommands: Commands {
         CommandMenu("Go") {
 
             Button {
-                navigationHistory.back()
+                navigationModel.back()
             } label: {
                 Label("Back", systemImage: "chevron.backward")
             }
             .keyboardShortcut("[", modifiers: [.command])
-            .disabled(!navigationHistory.canGoBack())
+            .disabled(!navigationModel.canGoBack())
 
             Button {
-                navigationHistory.forward()
+                navigationModel.forward()
             } label: {
                 Label("Forward", systemImage: "chevron.forward")
             }
             .keyboardShortcut("]", modifiers: [.command])
-            .disabled(!navigationHistory.canGoForward())
+            .disabled(!navigationModel.canGoForward())
 
             Button {
                 parentNavigableProxy?.navigateToParent()

--- a/Reconnect/Model/ApplicationModel.swift
+++ b/Reconnect/Model/ApplicationModel.swift
@@ -147,7 +147,7 @@ class ApplicationModel: NSObject {
 
     let transfersModel = TransfersModel()
     let libraryModel = LibraryModel()
-    let navigationHistory = NavigationHistory(section: .disconnected)
+    let navigationModel = NavigationModel(section: .disconnected)
 
     private let keyedDefaults = KeyedDefaults<SettingsKey>()
 

--- a/Reconnect/Model/DirectoryModel.swift
+++ b/Reconnect/Model/DirectoryModel.swift
@@ -38,7 +38,7 @@ class DirectoryModel {
     let transfersModel: TransfersModel
 
     @ObservationIgnored
-    private let navigationHistory: NavigationHistory
+    private let navigationModel: NavigationModel
 
     @ObservationIgnored
     private let deviceModel: DeviceModel
@@ -54,13 +54,13 @@ class DirectoryModel {
 
     init(applicationModel: ApplicationModel,
          transfersModel: TransfersModel,
-         navigationHistory: NavigationHistory,
+         navigationModel: NavigationModel,
          deviceModel: DeviceModel,
          driveInfo: FileServer.DriveInfo,
          path: String) {
         self.applicationModel = applicationModel
         self.transfersModel = transfersModel
-        self.navigationHistory = navigationHistory
+        self.navigationModel = navigationModel
         self.deviceModel = deviceModel
         self.driveInfo = driveInfo
         self.path = path
@@ -91,7 +91,7 @@ class DirectoryModel {
     }
 
     func navigate(to path: String) {
-        navigationHistory.navigate(to: .directory(deviceModel.id, driveInfo, path))
+        navigationModel.navigate(to: .directory(deviceModel.id, driveInfo, path))
     }
 
     private func update() {

--- a/Reconnect/ReconnectApp.swift
+++ b/Reconnect/ReconnectApp.swift
@@ -32,12 +32,12 @@ struct ReconnectApp: App {
         BrowserWindow(applicationModel: appDelegate.applicationModel,
                       transfersModel: appDelegate.applicationModel.transfersModel,
                       libraryModel: appDelegate.applicationModel.libraryModel,
-                      navigationHistory: appDelegate.applicationModel.navigationHistory)
+                      navigationModel: appDelegate.applicationModel.navigationModel)
 
         TransfersWindow()
             .environment(appDelegate.applicationModel)
             .environment(appDelegate.applicationModel.transfersModel)
-            .environment(appDelegate.applicationModel.navigationHistory)
+            .environment(appDelegate.applicationModel.navigationModel)
 
         Settings {
             SettingsView()

--- a/Reconnect/Software Index/Views/ProgramView.swift
+++ b/Reconnect/Software Index/Views/ProgramView.swift
@@ -25,14 +25,14 @@ class ProgramViewModel: ParentNavigable {
 
     let canNavigateToParent = true
 
-    private let navigationHistory: NavigationHistory
+    private let navigationModel: NavigationModel
 
-    init(navigationHistory: NavigationHistory) {
-        self.navigationHistory = navigationHistory
+    init(navigationModel: NavigationModel) {
+        self.navigationModel = navigationModel
     }
 
     func navigateToParent() {
-        self.navigationHistory.navigate(to: .softwareIndex)
+        self.navigationModel.navigate(to: .softwareIndex)
     }
 
 }
@@ -45,8 +45,8 @@ struct ProgramView: View {
 
     let program: Program
 
-    init(navigationHistory: NavigationHistory, program: Program) {
-        _programViewModel = State(initialValue: ProgramViewModel(navigationHistory: navigationHistory))
+    init(navigationModel: NavigationModel, program: Program) {
+        _programViewModel = State(initialValue: ProgramViewModel(navigationModel: navigationModel))
         self.program = program
     }
 

--- a/Reconnect/Software Index/Views/ProgramsView.swift
+++ b/Reconnect/Software Index/Views/ProgramsView.swift
@@ -22,7 +22,7 @@ import SwiftUI
 
 struct ProgramsView: View {
 
-    @Environment(NavigationHistory.self) private var navigationHistory
+    @Environment(NavigationModel.self) private var navigationModel
 
     @EnvironmentObject private var libraryModel: LibraryModel
 
@@ -41,7 +41,7 @@ struct ProgramsView: View {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 240))], spacing: 0) {
                         ForEach(libraryModel.filteredPrograms) { program in
                             Button {
-                                navigationHistory.navigate(to: .program(program))
+                                navigationModel.navigate(to: .program(program))
                             } label: {
                                 ItemView(imageURL: program.iconURL,
                                          title: program.name)

--- a/Reconnect/Toolbars/NavigationToolbar.swift
+++ b/Reconnect/Toolbars/NavigationToolbar.swift
@@ -21,7 +21,7 @@ import SwiftUI
 struct NavigationToolbar: CustomizableToolbarContent {
 
     @Environment(ApplicationModel.self) private var applicationModel
-    @Environment(NavigationHistory.self) private var navigationHistory
+    @Environment(NavigationModel.self) private var navigationModel
 
     @FocusedObject private var parentNavigable: ParentNavigableProxy?
 
@@ -35,9 +35,9 @@ struct NavigationToolbar: CustomizableToolbarContent {
                 HStack(spacing: 8) {
 
                     Menu {
-                        ForEach(navigationHistory.previousItems) { item in
+                        ForEach(navigationModel.previousItems) { item in
                             Button {
-                                navigationHistory.navigate(item)
+                                navigationModel.navigate(item)
                             } label: {
                                 SectionLabel(section: item.section)
                             }
@@ -46,16 +46,16 @@ struct NavigationToolbar: CustomizableToolbarContent {
                     } label: {
                         Label("Back", systemImage: "chevron.backward")
                     } primaryAction: {
-                        navigationHistory.back()
+                        navigationModel.back()
                     }
                     .menuIndicator(.hidden)
-                    .disabled(!navigationHistory.canGoBack())
-                    .id(navigationHistory.generation)
+                    .disabled(!navigationModel.canGoBack())
+                    .id(navigationModel.generation)
 
                     Menu {
-                        ForEach(navigationHistory.nextItems) { item in
+                        ForEach(navigationModel.nextItems) { item in
                             Button {
-                                navigationHistory.navigate(item)
+                                navigationModel.navigate(item)
                             } label: {
                                 SectionLabel(section: item.section)
                             }
@@ -64,11 +64,11 @@ struct NavigationToolbar: CustomizableToolbarContent {
                     } label: {
                         Label("Forward", systemImage: "chevron.forward")
                     } primaryAction: {
-                        navigationHistory.forward()
+                        navigationModel.forward()
                     }
                     .menuIndicator(.hidden)
-                    .disabled(!navigationHistory.canGoForward())
-                    .id(navigationHistory.generation)
+                    .disabled(!navigationModel.canGoForward())
+                    .id(navigationModel.generation)
 
                 }
                 .help("See folders you viewed previously")

--- a/Reconnect/Utilities/NavigationModel.swift
+++ b/Reconnect/Utilities/NavigationModel.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 @MainActor @Observable
-class NavigationHistory {
+class NavigationModel {
 
     struct Item: Identifiable, Equatable {
         let id = UUID()

--- a/Reconnect/Views/BrowserView.swift
+++ b/Reconnect/Views/BrowserView.swift
@@ -25,7 +25,7 @@ struct BrowserView: View {
 
     @Environment(ApplicationModel.self) private var applicationModel
     @Environment(TransfersModel.self) private var transfersModel
-    @Environment(NavigationHistory.self) private var navigationHistory
+    @Environment(NavigationModel.self) private var navigationModel
 
     @ObservedObject private var libraryModel: LibraryModel
 
@@ -48,14 +48,14 @@ struct BrowserView: View {
         NavigationSplitView {
             Sidebar()
         } detail: {
-            switch navigationHistory.currentItem?.section {
+            switch navigationModel.currentItem?.section {
             case .disconnected:
                 DisconnectedView()
             case .drive(let deviceId, let driveInfo):
                 withDeviceModel { deviceModel in
                     DirectoryView(applicationModel: applicationModel,
                                   transfersModel: transfersModel,
-                                  navigationHistory: navigationHistory,
+                                  navigationModel: navigationModel,
                                   deviceModel: deviceModel,
                                   driveInfo: driveInfo,
                                   path: driveInfo.path)
@@ -65,7 +65,7 @@ struct BrowserView: View {
                 withDeviceModel { deviceModel in
                     DirectoryView(applicationModel: applicationModel,
                                   transfersModel: transfersModel,
-                                  navigationHistory: navigationHistory,
+                                  navigationModel: navigationModel,
                                   deviceModel: deviceModel,
                                   driveInfo: driveInfo,
                                   path: path)
@@ -79,7 +79,7 @@ struct BrowserView: View {
                 ProgramsView()
                     .environmentObject(libraryModel)
             case .program(let program):
-                ProgramView(navigationHistory: navigationHistory, program: program)
+                ProgramView(navigationModel: navigationModel, program: program)
                     .environmentObject(libraryModel)
             case .none:
                 Text("Nothing selected!")

--- a/Reconnect/Views/DirectoryView.swift
+++ b/Reconnect/Views/DirectoryView.swift
@@ -29,14 +29,14 @@ struct DirectoryView: View {
 
     init(applicationModel: ApplicationModel,
          transfersModel: TransfersModel,
-         navigationHistory: NavigationHistory,
+         navigationModel: NavigationModel,
          deviceModel: DeviceModel,
          driveInfo: FileServer.DriveInfo,
          path: String) {
         self.applicationModel = applicationModel
         _directoryModel = State(initialValue: DirectoryModel(applicationModel: applicationModel,
                                                              transfersModel: transfersModel,
-                                                             navigationHistory: navigationHistory,
+                                                             navigationModel: navigationModel,
                                                              deviceModel: deviceModel,
                                                              driveInfo: driveInfo,
                                                              path: path))

--- a/Reconnect/Views/Sidebar/Sidebar.swift
+++ b/Reconnect/Views/Sidebar/Sidebar.swift
@@ -21,7 +21,7 @@ import SwiftUI
 struct Sidebar: NSViewRepresentable {
 
     @Environment(ApplicationModel.self) private var applicationModel
-    @Environment(NavigationHistory.self) private var navigationHistory
+    @Environment(NavigationModel.self) private var navigationModel
 
     public final class Coordinator: NSObject, SidebarContainerViewDelegate {
 
@@ -33,7 +33,7 @@ struct Sidebar: NSViewRepresentable {
 
         func sidebarContainerView(_ sidebarContainerView: SidebarContainerView,
                                   didSelectSection section: BrowserSection) {
-            parent.navigationHistory.navigate(to: section)
+            parent.navigationModel.navigate(to: section)
         }
 
     }
@@ -53,7 +53,7 @@ struct Sidebar: NSViewRepresentable {
     }
 
     func updateNSView(_ sidebarContainerView: SidebarContainerView, context: Context) {
-        sidebarContainerView.selectedSection = navigationHistory.currentItem!.section
+        sidebarContainerView.selectedSection = navigationModel.currentItem!.section
     }
 
 }

--- a/Reconnect/Windows/BrowserWindow.swift
+++ b/Reconnect/Windows/BrowserWindow.swift
@@ -27,16 +27,16 @@ struct BrowserWindow: Scene {
     private let applicationModel: ApplicationModel
     private let transfersModel: TransfersModel
     private let libraryModel: LibraryModel
-    private let navigationHistory: NavigationHistory
+    private let navigationModel: NavigationModel
 
     init(applicationModel: ApplicationModel,
          transfersModel: TransfersModel,
          libraryModel: LibraryModel,
-         navigationHistory: NavigationHistory) {
+         navigationModel: NavigationModel) {
         self.applicationModel = applicationModel
         self.transfersModel = transfersModel
         self.libraryModel = libraryModel
-        self.navigationHistory = navigationHistory
+        self.navigationModel = navigationModel
     }
 
     var body: some Scene {
@@ -56,7 +56,7 @@ struct BrowserWindow: Scene {
         }
         .environment(applicationModel)
         .environment(transfersModel)
-        .environment(navigationHistory)
+        .environment(navigationModel)
         .handlesExternalEvents(matching: [.browser, .settings, .settingsGeneral, .settingsDevices])
     }
 


### PR DESCRIPTION
Since this is a) a model object and, b) we’re using it to manage the whole navigation of the app, it makes sense to rename it.