### PR TITLE
fix: ↗️⬇️🗑️ Add icons to the file context menu

### DIFF
--- a/Reconnect/Views/DirectoryView.swift
+++ b/Reconnect/Views/DirectoryView.swift
@@ -125,25 +125,27 @@ struct DirectoryView: View {
             }
             .contextMenu(forSelectionType: FileServer.DirectoryEntry.ID.self) { items in
 
-                Button("Open") {
+                Button("Open", systemImage: "arrow.up.forward.square") {
                     directoryModel.navigate(to: items.first!)
                 }
                 .disabled(items.count != 1 || !(items.first?.isWindowsDirectory ?? false))
 
                 Divider()
 
-                Button("Download") {
+                Button("Download", systemImage: "display.and.arrow.down") {
                     directoryModel.download(items,
                                           to: FileManager.default.downloadsDirectory,
                                           convertFiles: applicationModel.convertFiles,
                                           completion: { _ in })
                 }
+                .disabled(items.count < 1)
 
                 Divider()
 
-                Button("Delete") {
+                Button("Delete", systemImage: "trash") {
                     directoryModel.delete(items)
                 }
+                .disabled(items.count < 1)
 
             } primaryAction: { items in
                 guard


### PR DESCRIPTION
This includes a drive-by fix to disable the Download and Delete menu items when there are no files selected.