### PR TITLE
fix: 📁 Ensure creating folders works on EPOC16 devices

### DIFF
--- a/Reconnect/Model/DeviceModel.swift
+++ b/Reconnect/Model/DeviceModel.swift
@@ -157,17 +157,6 @@ class DeviceModel: Identifiable, Equatable {
         return deviceConfiguration.id
     }
 
-    var installDirectory: String? {
-        switch machineType {
-        case .unknown, .pc, .mc, .hc, .winC:
-            return nil
-        case .series3, .series3acmx, .workabout, .siena, .series3c:
-            return .epoc16InstallDirectory
-        case .series5:
-            return .epoc32InstallDirectory
-        }
-    }
-
     var canCaptureScreenshot: Bool {
         switch machineType {
         case .unknown, .pc, .mc, .hc, .winC:
@@ -176,6 +165,43 @@ class DeviceModel: Identifiable, Equatable {
             return false
         case .series5:
             return true
+        }
+    }
+
+    /**
+     * Return a new folder name with a specific count.
+     *
+     * The expectation is that this will be called with increasing values of `index` (starting at 0), until a unique
+     * name is found. It is implemented as a function (as opposed to simply returning a default new folder basename to
+     * allow for per-platform customization around how the name changes with different values of index (e.g., EPOC16
+     * does not permit spaces in files, while EPOC32 does).
+     *
+     * This maybe localized in the future.
+     */
+    func synthesizeNewFolderName(index: UInt8) -> String {
+        if machineType.isEpoc32 {
+            if index == 0 {
+                return "untitled folder"
+            } else {
+                return "untitled folder \(index)"
+            }
+        } else {
+            if index == 0 {
+                return "FOLDER"
+            } else {
+                return "FOLDER\(index)"
+            }
+        }
+    }
+
+    var installDirectory: String? {
+        switch machineType {
+        case .unknown, .pc, .mc, .hc, .winC:
+            return nil
+        case .series3, .series3acmx, .workabout, .siena, .series3c:
+            return .epoc16InstallDirectory
+        case .series5:
+            return .epoc32InstallDirectory
         }
     }
 


### PR DESCRIPTION
EPOC16 devices require `8.3` filenames without spaces, so we synthesize platform-specific new folder names. This change includes a drive-by fix to ensure we're correctly ignoring case when checking for existing names.