### PR TITLE
fix: 📑 Ensure transfers work when switching between devices

### DIFF
--- a/macos/Reconnect/Views/DirectoryView.swift
+++ b/macos/Reconnect/Views/DirectoryView.swift
@@ -35,7 +35,6 @@ struct DirectoryView: View {
          path: String) {
         self.applicationModel = applicationModel
         _directoryModel = State(initialValue: DirectoryModel(applicationModel: applicationModel,
-                                                             transfersModel: transfersModel,
                                                              navigationModel: navigationModel,
                                                              deviceModel: deviceModel,
                                                              driveInfo: driveInfo,


### PR DESCRIPTION
This change injects the `FileSever` instance into `TransfersModel` (which is increasingly becoming just a long-running operation tracker) to ensure that we’re using a server bound to the current device, and that we’re not holding onto servers between device connections.

The legacy implementation was particularly problematic when switching between devices of different platforms, as we were holding onto the wrong type of file server client (EPOC16 vs EPOC32).