### PR TITLE
fix: 🚦 Make it faster to cancel backups

### DIFF
--- a/macos/Reconnect/Model/DeviceModel.swift
+++ b/macos/Reconnect/Model/DeviceModel.swift
@@ -622,7 +622,9 @@ extension DeviceModel {
 
         // Recursively list the files to work out what we need to download.
         progress.localizedDescription = "Listing files..."
-        let files = try transfersFileServer.dir(path: sourcePath, recursive: true)
+        let files = try transfersFileServer.dir(path: sourcePath,
+                                                recursive: true,
+                                                cancellationToken: cancellationToken)
 
         // Update the progress accordingly.
         progress.totalUnitCount = Int64(files.count)

--- a/macos/ReconnectCore/Sources/ReconnectCore/Utilities/CancellationToken.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Utilities/CancellationToken.swift
@@ -18,34 +18,32 @@
 
 import Foundation
 
-import ReconnectCore
-
-class CancellationToken {
+public class CancellationToken {
 
     private let lock = NSLock()
 
     private var _isCancelled = false
 
-    var isCancelled: Bool {
+    public var isCancelled: Bool {
         lock.withLock {
             return _isCancelled
         }
     }
 
-    init() {
+    public init() {
     }
 
-    func cancel() {
+    public func cancel() {
         lock.withLock {
             _isCancelled = true
         }
     }
 
-    func checkCancellation() throws {
+    public func checkCancellation() throws(PLPToolsError) {
         guard isCancelled else {
             return
         }
-        throw ReconnectError.cancelled
+        throw PLPToolsError.cancelled
     }
 
 }


### PR DESCRIPTION
This change introduces a `CancellationToken` to the `FileServer.dir` API to allow long running recursive directory listings to be cancelled.