### PR TITLE
fix: ⬆️ Upload files from the main menu and toolbar

### DIFF
--- a/macos/Reconnect/Commands/FileCommands.swift
+++ b/macos/Reconnect/Commands/FileCommands.swift
@@ -34,6 +34,12 @@ public struct FileCommands: Commands {
             .keyboardShortcut("N", modifiers: [.command, .shift])
             .disabled(!(fileManageableProxy?.canCreateNewFolder ?? false))
 
+            Button("Upload...", systemImage: "arrow.up.document") {
+                fileManageableProxy?.upload()
+            }
+            .keyboardShortcut("U", modifiers: [.command])
+            .disabled(!(fileManageableProxy?.canUpload ?? false))
+
             Button {
                 fileManageableProxy?.openSelection()
             } label: {

--- a/macos/Reconnect/Model/FileManageable.swift
+++ b/macos/Reconnect/Model/FileManageable.swift
@@ -44,4 +44,10 @@ protocol FileManageable {
     @MainActor
     func download()
 
+    @MainActor
+    var canUpload: Bool { get }
+
+    @MainActor
+    func upload()
+
 }

--- a/macos/Reconnect/Model/FileManageableProxy.swift
+++ b/macos/Reconnect/Model/FileManageableProxy.swift
@@ -36,6 +36,10 @@ class FileManageableProxy: ObservableObject, FileManageable {
         return _canDownload()
     }
 
+    var canUpload: Bool {
+        return _canUpload()
+    }
+
     private let _canOpenSelection: @MainActor () -> Bool
     private let _openSelection: @MainActor () -> Void
     private let _canCreateNewFolder: @MainActor () -> Bool
@@ -44,6 +48,8 @@ class FileManageableProxy: ObservableObject, FileManageable {
     private let _delete: @MainActor () -> Void
     private let _canDownload: @MainActor () -> Bool
     private let _download: @MainActor () -> Void
+    private let _canUpload: @MainActor () -> Bool
+    private let _upload: @MainActor () -> Void
 
     init(_ fileManageable: FileManageable) {
         _canOpenSelection = {
@@ -70,6 +76,12 @@ class FileManageableProxy: ObservableObject, FileManageable {
         _download = {
             fileManageable.download()
         }
+        _canUpload = {
+            return fileManageable.canUpload
+        }
+        _upload = {
+            fileManageable.upload()
+        }
     }
 
     func openSelection() {
@@ -86,6 +98,10 @@ class FileManageableProxy: ObservableObject, FileManageable {
 
     func download() {
         _download()
+    }
+
+    func upload() {
+        _upload()
     }
 
 }

--- a/macos/Reconnect/Model/TransfersModel.swift
+++ b/macos/Reconnect/Model/TransfersModel.swift
@@ -29,7 +29,7 @@ class TransfersModel {
     init() {
     }
 
-    func newTransfer(fileReference: FileReference) -> Transfer {
+    nonisolated func newTransfer(fileReference: FileReference) -> Transfer {
         TransfersWindow.reveal()
         let transfer = Transfer(item: fileReference)
         DispatchQueue.main.async {

--- a/macos/Reconnect/Toolbars/FileToolbar.swift
+++ b/macos/Reconnect/Toolbars/FileToolbar.swift
@@ -34,6 +34,14 @@ struct FileToolbar: CustomizableToolbarContent {
             .disabled(!(fileManageableProxy?.canCreateNewFolder ?? false))
         }
 
+        ToolbarItem(id: "upload") {
+            Button("Upload", systemImage: "arrow.up.document") {
+                fileManageableProxy?.upload()
+            }
+            .help("Upload files and folders")
+            .disabled(!(fileManageableProxy?.canUpload ?? false))
+        }
+
         ToolbarItem(id: "download") {
             Button {
                 fileManageableProxy?.download()

--- a/macos/Reconnect/Windows/TransfersWindow.swift
+++ b/macos/Reconnect/Windows/TransfersWindow.swift
@@ -22,7 +22,7 @@ import Interact
 
 struct TransfersWindow: Scene {
 
-    static func reveal() {
+    nonisolated static func reveal() {
         DispatchQueue.main.async {
             NSWorkspace.shared.open(.transfers)
         }


### PR DESCRIPTION
While it was possible to drag and drop files to upload them, this change adds a dedicated toolbar button and menu item. It also includes a drive-by fix to ensure uploaded files are highlighted on completion.