### PR TITLE
fix: 🧟 Stop zombie devices remaining in the UI after disconnection

### DIFF
--- a/macos/reconnectd/Daemon.swift
+++ b/macos/reconnectd/Daemon.swift
@@ -232,8 +232,13 @@ extension Daemon: NCPDelegate {
 
     func ncp(_ ncp: NCP, didChangeConnectionState isConnected: Bool) {
         dispatchPrecondition(condition: .onQueue(.main))
+        // Right now it connections and disconnections don't seem to be perfectly matched so we explicitly gate these
+        // on our internal state to ensure we give clients matched pairs of events.
         if isConnected {
             logger.notice("Device connected on port \(ncp.port).")
+            guard !connectedDevices.contains(where: { $0.port == ncp.port }) else {
+                return
+            }
             let connectionDetails = DeviceConnectionDetails(port: ncp.port)
             connectedDevices.insert(connectionDetails)
             let count = connectedDevices.count


### PR DESCRIPTION
The daemon wasn't sending matched connect/disconnect messages to the app, meaning that it would sometimes show disconnected devices or duplicate entries in the sidebar.