### PR TITLE
fix: 🖼️ Show program icons in the navigation history

### DIFF
--- a/macos/Reconnect/Model/BrowserSection.swift
+++ b/macos/Reconnect/Model/BrowserSection.swift
@@ -54,26 +54,32 @@ extension BrowserSection {
         }
     }
 
-    var image: String {
+    @ViewBuilder var icon: some View {
         switch self {
         case .disconnected:
-            return "Disconnected16"
+            Image(.disconnected16)
         case .drive(_, let driveInfo, let platform):
-            return DisplayHelpers.imageForDrive(driveInfo.drive,
-                                                mediaType: driveInfo.mediaType,
-                                                platform: platform)
+            Image(DisplayHelpers.imageForDrive(driveInfo.drive,
+                                               mediaType: driveInfo.mediaType,
+                                               platform: platform))
         case .directory:
-            return "Folder16"
+            Image(.folder16)
         case .device:
-            return "Psion16"
+            Image(.psion16)
         case .softwareIndex:
-            return "Install16"
-        case .program:
-            return "FileUnknown16"
+            Image(.install16)
+        case .program(let program):
+            if let iconURL = program.iconURL {
+                FixedSizeAsyncImage(url: iconURL, size: CGSize(width: 16, height: 16)) {
+                    Image(.fileUnknown16)
+                }
+            } else {
+                Image(.fileUnknown16)
+            }
         case .backupSet(_):
-            return "Backup16"
+            Image(.backup16)
         case .backup(_):
-            return "Backups16"
+            Image(.backup16)
         }
     }
 

--- a/macos/Reconnect/Views/Common/FixedSizeAsyncImage.swift
+++ b/macos/Reconnect/Views/Common/FixedSizeAsyncImage.swift
@@ -1,0 +1,63 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2026 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import SwiftUI
+import ReconnectCore
+
+/**
+ * Fixed size image that loads its content asynchronously from a URL.
+ *
+ * There is no way this view should need to exist---it is entirely a side effect of bugs in SwiftUI on macOS whereby
+ * `Image` will not respect `resizable` or `frame` modifiers when used in a menu.
+ */
+struct FixedSizeAsyncImage<Placeholder: View>: View {
+
+    @Environment(\.displayScale) var displayScale
+
+    @MainActor @State var nsImage: NSImage? = nil
+
+    let url: URL
+    let size: CGSize
+    let placeholder: Placeholder
+
+    init(url: URL, size: CGSize, @ViewBuilder placeholder: () -> Placeholder) {
+        self.url = url
+        self.size = size
+        self.placeholder = placeholder()
+    }
+
+    var body: some View {
+        Group {
+            if let nsImage {
+                Image(nsImage: nsImage)
+            } else {
+                placeholder
+            }
+        }
+        .task {
+            guard
+                let (data, _) = try? await URLSession.shared.data(from: url),
+                let nsImage = NSImage(data: data)
+            else {
+                return
+            }
+            self.nsImage = nsImage.resized(size: size, scale: displayScale)
+        }
+    }
+
+}

--- a/macos/Reconnect/Views/SectionLabel.swift
+++ b/macos/Reconnect/Views/SectionLabel.swift
@@ -27,7 +27,12 @@ struct SectionLabel: View {
     }
 
     var body: some View {
-        Label(section.title, image: section.image)
+        Label {
+            Text(section.title)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } icon: {
+            section.icon
+        }
     }
 
 }

--- a/macos/Reconnect/Views/Sidebar/SidebarSectionCell.swift
+++ b/macos/Reconnect/Views/Sidebar/SidebarSectionCell.swift
@@ -17,10 +17,17 @@
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 import AppKit
+import SwiftUI
 
 class SidebarSectionCell: NSTableCellView, ConfigurableSidebarCell {
 
+    struct LayoutMetrics {
+        static let horizontalMargin: CGFloat = 5.0
+    }
+
     static let identifier = NSUserInterfaceItemIdentifier(rawValue: "SidebarSectionCell")
+
+    private var hostingView: NSHostingView<SectionLabel>?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -47,9 +54,28 @@ class SidebarSectionCell: NSTableCellView, ConfigurableSidebarCell {
         guard case .section(let section) = node.type else {
             fatalError("Unsupported node type \(node.type).")
         }
-        textField?.stringValue = section.title
-        imageView?.image = NSImage(named: section.image)
-        textField?.isEditable = false
+        host(SectionLabel(section: section))
+    }
+
+    private func host(_ content: SectionLabel) {
+        if let hostingView = hostingView {
+            hostingView.rootView = content
+        } else {
+            let newHostingView = NSHostingView(rootView: content)
+            newHostingView.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(newHostingView)
+            setupConstraints(for: newHostingView)
+            self.hostingView = newHostingView
+        }
+    }
+
+    func setupConstraints(for view: NSView) {
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: LayoutMetrics.horizontalMargin),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -LayoutMetrics.horizontalMargin),
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+        ])
     }
 
 }

--- a/macos/ReconnectCore/Sources/ReconnectCore/Extensions/Image.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Extensions/Image.swift
@@ -1,0 +1,51 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2026 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import SwiftUI
+
+extension NSImage {
+
+    public func resized(size: NSSize, scale: CGFloat) -> NSImage? {
+        if let representation = NSBitmapImageRep(bitmapDataPlanes: nil,
+                                                 pixelsWide: Int(size.width * scale),
+                                                 pixelsHigh: Int(size.height * scale),
+                                                 bitsPerSample: 8,
+                                                 samplesPerPixel: 4,
+                                                 hasAlpha: true,
+                                                 isPlanar: false,
+                                                 colorSpaceName: .calibratedRGB,
+                                                 bytesPerRow: 0,
+                                                 bitsPerPixel: 0) {
+            representation.size = size
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: representation)
+            draw(in: NSRect(x: 0, y: 0, width: size.width, height: size.height),
+                 from: .zero,
+                 operation: .copy,
+                 fraction: 1.0)
+            NSGraphicsContext.restoreGraphicsState()
+
+            let image = NSImage(size: size)
+            image.addRepresentation(representation)
+
+            return image
+        }
+
+        return nil
+    }
+}


### PR DESCRIPTION
This change switches to using SwiftUI for sidebar rows/cells and starts using `SectionLabel` again. It also introduces a new `FixedSizeAsyncImage` to work around SwiftUI bugs and ensure program icons aren’t too big when shown in the navigation history.