### PR TITLE
fix: 🛡️ Make file selection tracking more robust

### DIFF
--- a/macos/Reconnect/Model/DirectoryModel.swift
+++ b/macos/Reconnect/Model/DirectoryModel.swift
@@ -132,9 +132,14 @@ class DirectoryModel {
                 throw error
             }
             DispatchQueue.main.sync {
-                var newFile = file
-                newFile.path = newPath
-                newFile.name = newName
+                let newFile = FileServer.DirectoryEntry(path: newPath,
+                                                        name: newName,
+                                                        size: file.size,
+                                                        attributes: file.attributes,
+                                                        modificationDate: file.modificationDate,
+                                                        uid1: file.uid1,
+                                                        uid2: file.uid2,
+                                                        uid3: file.uid3)
                 var updatedFiles = self.files
                 updatedFiles.removeAll { $0.path == file.path }
                 let index = updatedFiles.partitioningIndex {

--- a/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
@@ -130,32 +130,30 @@ public class FileServer: @unchecked Sendable {
 
     public struct DirectoryEntry: Identifiable, Hashable, Sendable {
 
-        public var id: String {
-            return path
-        }
-
         public var isDirectory: Bool {
             return attributes.contains(.directory)
         }
 
-        public var path: String
-        public var name: String
-        public var size: UInt32
-        public var attributes: FileAttributes
-        public var modificationDate: Date
+        public let id: String
+        public let path: String
+        public let name: String
+        public let size: UInt32
+        public let attributes: FileAttributes
+        public let modificationDate: Date
 
-        public var uid1: UInt32
-        public var uid2: UInt32
-        public var uid3: UInt32
+        public let uid1: UInt32
+        public let uid2: UInt32
+        public let uid3: UInt32
 
         public init(path: String,
-             name: String,
-             size: UInt32,
-             attributes: FileAttributes,
-             modificationDate: Date,
-             uid1: UInt32,
-             uid2: UInt32,
-             uid3: UInt32) {
+                    name: String,
+                    size: UInt32,
+                    attributes: FileAttributes,
+                    modificationDate: Date,
+                    uid1: UInt32,
+                    uid2: UInt32,
+                    uid3: UInt32) {
+            self.id = path.lowercased()
             self.path = path
             self.name = name
             self.size = size
@@ -176,6 +174,7 @@ public class FileServer: @unchecked Sendable {
             let modificationTimeInterval = TimeInterval(modificationTime.getTime())
             let modificationDate = Date(timeIntervalSince1970: modificationTimeInterval)
 
+            self.id = filePath.lowercased()
             self.path = filePath
             self.name = name
             self.size = entry.getSize()


### PR DESCRIPTION
This change ensures `FileServer.DirectoryEntry` identifiers are always lowercased as we know we're referencing files on a case-insensitive file system. This isn't strictly necessary, but it makes Reconnect more robust to plptools handling case inconsistently (see https://github.com/plptools/plptools/pull/74).