### PR TITLE
fix: 🏃 Ensure installers can run programs when multiple devices are connected

### DIFF
--- a/macos/Reconnect/Model/InstallerModel.swift
+++ b/macos/Reconnect/Model/InstallerModel.swift
@@ -404,7 +404,11 @@ extension InstallerModel: SisInstallIoHandler {
     func sisInstallRun(sis: Sis.File, path: String, flags: Sis.RunFlags) {
         dispatchPrecondition(condition: .notOnQueue(.main))
         do {
-            let services = PsionClient()
+            guard let device else {
+                throw PLPToolsError.E_PSI_FILE_DISC
+            }
+            let services = PsionClient(fileServer: device.fileServer,
+                                       remoteCommandServicesClient: device.remoteCommandServicesClient)
             try services.runProgram(path: path)
         } catch {
             print("Failed to run path '\(path)' with error '\(error)'.")

--- a/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
@@ -214,7 +214,7 @@ public class FileServer: @unchecked Sendable {
 
     private var client = RFSVClient()
 
-    public init(host: String = "127.0.0.1", port: Int32 = 7501) {
+    public init(host: String = "127.0.0.1", port: Int32) {
         self.host = host
         self.port = port
     }

--- a/macos/ReconnectCore/Sources/ReconnectCore/PLP/PsionClient.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/PLP/PsionClient.swift
@@ -20,19 +20,20 @@ import Foundation
 
 public class PsionClient {
 
-    let fileServer = FileServer()
-    let remoteCommandServices = RemoteCommandServicesClient()
+    let fileServer: FileServer
+    let remoteCommandServicesClient: RemoteCommandServicesClient
 
-    public init() {
-        
+    public init(fileServer: FileServer, remoteCommandServicesClient: RemoteCommandServicesClient) {
+        self.fileServer = fileServer
+        self.remoteCommandServicesClient = remoteCommandServicesClient
     }
 
     public func runProgram(path: String) throws {
         let attributes = try fileServer.getExtendedAttributes(path: path)
         if attributes.uid1 == .dynamicLibraryUid {
-            try remoteCommandServices.execProgram(program: path)
+            try remoteCommandServicesClient.execProgram(program: path)
         } else {
-            try remoteCommandServices.execProgram(program: "Z:\\System\\Apps\\OPL\\OPL.app", args: "A" + path)
+            try remoteCommandServicesClient.execProgram(program: "Z:\\System\\Apps\\OPL\\OPL.app", args: "A" + path)
         }
     }
 

--- a/macos/ReconnectCore/Sources/ReconnectCore/PLP/RemoteCommandServicesClient.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/PLP/RemoteCommandServicesClient.swift
@@ -32,7 +32,7 @@ public class RemoteCommandServicesClient {
 
     private var client = RPCSClient()
 
-    public init(host: String = "127.0.0.1", port: Int32 = 7501) {
+    public init(host: String = "127.0.0.1", port: Int32) {
         self.host = host
         self.port = port
     }


### PR DESCRIPTION
The `PsionClient` (which is responsible for running programs) was incorrectly constructing `FileServer` and `RemoteCommandServicesClient` instances using the default port, rather than reusing the ones owned by the device.