### PR TITLE
fix: 📁 Ensure all contents are copied when uploading directories

### DIFF
--- a/macos/Reconnect/Model/DeviceModel.swift
+++ b/macos/Reconnect/Model/DeviceModel.swift
@@ -903,7 +903,13 @@ extension DeviceModel {
         let fileManager = FileManager.default
 
         // Recursively list the files to work out what we need to upload.
-        let files = try fileManager.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: [.isDirectoryKey])
+        guard let enumerator = fileManager.enumerator(at: sourceURL,
+                                                      includingPropertiesForKeys: [.nameKey, .isDirectoryKey])
+        else {
+            throw ReconnectError.directoryListingError
+        }
+        let files = enumerator
+            .compactMap { $0 as? URL }
             .filter { $0.lastPathComponent != ".DS_Store" }
 
         // Create the directory to upload to.
@@ -924,7 +930,7 @@ extension DeviceModel {
 
             // Create the destination directory, or copy the file.
             progress.localizedAdditionalDescription = file.path
-            if file.hasDirectoryPath {
+            if try file.isDirectory {
                 try transfersFileServer.mkdir(path: innerDestinationPath)
                 progress.completedUnitCount += 1
             } else {

--- a/macos/ReconnectCore/Sources/ReconnectCore/Extensions/URL.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Extensions/URL.swift
@@ -43,6 +43,12 @@ extension URL {
         return URL(address: "support@jbmorley.co.uk", subject: subject)!
     }()
 
+    public var isDirectory: Bool {
+        get throws {
+            (try resourceValues(forKeys: [.isDirectoryKey])).isDirectory == true
+        }
+    }
+
     public func appendingPathComponents(_ pathComponents: [String]) -> URL {
         return pathComponents.reduce(self) { url, pathComponent in
             return url.appendingPathComponent(pathComponent)

--- a/macos/ReconnectCore/Sources/ReconnectCore/Model/ReconnectError.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Model/ReconnectError.swift
@@ -35,6 +35,7 @@ public enum ReconnectError: Error {
     case cancelled
     case unknownDownloadFailure
     case unsupportedImageFormat
+    case directoryListingError
 }
 
 extension ReconnectError: LocalizedError {
@@ -69,6 +70,8 @@ extension ReconnectError: LocalizedError {
             return "Unknown download failure."
         case .unsupportedImageFormat:
             return "Unsupported image format."
+        case .directoryListingError:
+            return "Failed to list directory."
         }
     }
 


### PR DESCRIPTION
This was a real goof—I was incorrectly using the non-recursive `FileManger.contentsOfDirectory` instead of `FileManager.enumerator`.