### PR TITLE
fix: 📁 Improve folder upload reliability

### DIFF
--- a/macos/Reconnect/Model/DeviceModel.swift
+++ b/macos/Reconnect/Model/DeviceModel.swift
@@ -904,7 +904,8 @@ extension DeviceModel {
 
         // Recursively list the files to work out what we need to upload.
         guard let enumerator = fileManager.enumerator(at: sourceURL,
-                                                      includingPropertiesForKeys: [.nameKey, .isDirectoryKey])
+                                                      includingPropertiesForKeys: [.nameKey, .isDirectoryKey],
+                                                      options: [.producesRelativePathURLs])
         else {
             throw ReconnectError.directoryListingError
         }
@@ -929,8 +930,7 @@ extension DeviceModel {
             }
 
             // Determine the destination path.
-            let relativePath = String(file.path.dropFirst(sourceURL.path().count))
-            let innerDestinationPath = destinationPath.appendingWindowsPathComponent(relativePath)
+            let innerDestinationPath = destinationPath.appendingWindowsPathComponent(file.relativePath.windowsPath)
 
             // Create the destination directory, or copy the file.
             progress.localizedAdditionalDescription = file.path

--- a/macos/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Extensions/String.swift
@@ -60,12 +60,23 @@ public extension String {
         return windowsPathComponents.last ?? ""
     }
 
+    /// Components of a macOS path (using / path separator).
+    var pathComponents: [String] {
+        return NSString(string: self).pathComponents
+    }
+
     var pathExtension: String {
         return (self as NSString).pathExtension
     }
 
+    /// Components of a Windows path (using \ path separator).
     var windowsPathComponents: [String] {
-        return components(separatedBy: "\\").filter { !$0.isEmpty }
+        return components(separatedBy: String.windowsPathSeparator).filter { !$0.isEmpty }
+    }
+
+    /// Convert macOS path separators to Windows path separators.
+    var windowsPath: String {
+        return pathComponents.joined(separator: .windowsPathSeparator)
     }
 
     init(contentsOfResource resource: String) {

--- a/macos/ReconnectCore/Tests/ReconnectCoreTests/WindowsPathTests.swift
+++ b/macos/ReconnectCore/Tests/ReconnectCoreTests/WindowsPathTests.swift
@@ -44,4 +44,13 @@ final class WindowsPathTests: XCTestCase {
         XCTAssertEqual("C:\\Foo\\".ensuringTrailingWindowsPathSeparator(isPresent: false), "C:\\Foo")
     }
 
+    func testWindowsPath() {
+
+        XCTAssertEqual("foo/bar".windowsPath, "foo\\bar")
+        XCTAssertEqual("foo/bar/baz".windowsPath, "foo\\bar\\baz")
+        XCTAssertEqual("foo\\bar\\baz".windowsPath, "foo\\bar\\baz")
+        XCTAssertEqual("foo/bar\\baz".windowsPath, "foo\\bar\\baz")
+
+    }
+
 }


### PR DESCRIPTION
Unfortunately the macOS FileSystem enumerator isn’t guaranteed to give us normalized paths (and resolving symlinks doesn’t work in all scenarios), so we instead ask the iterator to preserve relative paths on our behalf.

This includes a drive-by fix to guarantee we’re using Windows path separators when uploading files. (We were getting away without this as plptools is permissive, but it’s just bad hygiene.)