### PR TITLE
fix: 💾 Support listing the extended attributes of drives

### DIFF
--- a/macos/ReconnectCore/Sources/ReconnectCore/Extensions/Date.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/Extensions/Date.swift
@@ -1,0 +1,25 @@
+// Reconnect -- Psion connectivity for macOS
+//
+// Copyright (C) 2024-2026 Jason Morley
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+import Foundation
+
+extension Date {
+
+    static let fatEpoch = Date(timeIntervalSince1970: 315532800)  // 1980-01-01
+
+}

--- a/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
+++ b/macos/ReconnectCore/Sources/ReconnectCore/PLP/FileServer.swift
@@ -292,6 +292,21 @@ public class FileServer: @unchecked Sendable {
     private func workQueue_getExtendedAttributes(path: String) throws(ReconnectError) -> DirectoryEntry {
         dispatchPrecondition(condition: .onQueue(workQueue))
         try workQueue_connect()
+
+        // EPOC16 and EPOC32 will barf if we ask for the extended attributes of a volume root so we intercept this and
+        // return something sane to make this API safer and less brittle for clients.
+        if path.isRoot {
+            let driveInfo = try workQueue_devinfo(drive: path)
+            return FileServer.DirectoryEntry(path: path,
+                                             name: driveInfo.name ?? "",
+                                             size: 0,
+                                             attributes: .directory,
+                                             modificationDate: .fatEpoch,
+                                             uid1: 0,
+                                             uid2: 0,
+                                             uid3: 0)
+        }
+
         var entry = PlpDirent()
         let result = client.fgeteattr(path, &entry)
         guard result == .E_PSI_GEN_NONE else {


### PR DESCRIPTION
I’m not sure if it’s possible for a user to exercise this code path through the Reconnect UI but, just in case, this makes it safe to get the attributes of a drive root.