### PR TITLE
fix: 🙈 Disable the backup button and menu when no devices are connected

### DIFF
--- a/macos/Reconnect/Commands/DeviceCommands.swift
+++ b/macos/Reconnect/Commands/DeviceCommands.swift
@@ -31,6 +31,14 @@ public struct DeviceCommands: Commands {
         return true
     }
 
+    var canBackUp: Bool {
+        guard let deviceModel = deviceProxy?.deviceModel, !deviceModel.isBackingUp else {
+            return false
+        }
+        return true
+
+    }
+
     public var body: some Commands {
 
         CommandMenu("Device") {
@@ -51,7 +59,7 @@ public struct DeviceCommands: Commands {
             Button("Install Reconnect Tools...", systemImage: "shippingbox") {
                 deviceProxy?.deviceModel.installGuestTools()
             }
-            .disabled(deviceProxy == nil)
+            .disabled(!canBackUp)
 
         }
 

--- a/macos/Reconnect/Model/DeviceModel.swift
+++ b/macos/Reconnect/Model/DeviceModel.swift
@@ -157,6 +157,9 @@ class DeviceModel: Identifiable, Equatable, @unchecked Sendable {
     @MainActor
     var isCapturingScreenshot: Bool = false
 
+    @MainActor
+    var isBackingUp: Bool = false
+
     var id: UUID {
         return deviceConfiguration.id
     }
@@ -372,7 +375,14 @@ class DeviceModel: Identifiable, Equatable, @unchecked Sendable {
 
         let backupIdentifier = UUID()
         DispatchQueue.main.sync {
+            isBackingUp = true
             self.delegate?.deviceModel(deviceModel: self, willStartBackupWithIdentifier: backupIdentifier)
+        }
+
+        defer {
+            DispatchQueue.main.sync {
+                isBackingUp = false
+            }
         }
 
         do {

--- a/macos/Reconnect/Toolbars/DeviceToolbar.swift
+++ b/macos/Reconnect/Toolbars/DeviceToolbar.swift
@@ -31,6 +31,13 @@ struct DeviceToolbar: CustomizableToolbarContent {
         return true
     }
 
+    var canBackUp: Bool {
+        guard let deviceModel = deviceProxy?.deviceModel, !deviceModel.isBackingUp else {
+            return false
+        }
+        return true
+    }
+
     init() {
     }
 
@@ -53,7 +60,7 @@ struct DeviceToolbar: CustomizableToolbarContent {
                 Label("Back Up", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
             }
             .help("Back up your Psion's internal drive")
-            .disabled(deviceProxy == nil)
+            .disabled(!canBackUp)
         }
 
     }


### PR DESCRIPTION
This is a work around for what is, I presume, a SwiftUI bug on earlier macOS releases. We’ve seen an issue on Sequoia where the backup menu item isn’t correctly disabled when the device isn’t selected, but the screenshot menu item behaves correctly. The only difference is the indirection through the computed `canCaptureScreenshot` variable which I guess is forcing a reevaluation on Sequoia that doesn’t otherwise happen. This change also tracks the long-running backup operation explicitly and keeps the button disabled during active backups. This also updates the toolbar button behavior to match.